### PR TITLE
Minimum wand version in setup.py

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=["elifecleaner"],
     license="MIT",
-    install_requires=["wand"],
+    install_requires=["wand >= 0.5.2"],
     url="https://github.com/elifesciences/elife-cleaner",
     maintainer="eLife Sciences Publications Ltd.",
     maintainer_email="tech-team@elifesciences.org",


### PR DESCRIPTION
Since `WandRuntimeError` was introduced in Wand version `0.5.2`, be more explicit about the required version in `setup.py`.