### PR TITLE
Parse article xml enhancements

### DIFF
--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -40,14 +40,18 @@ def parse_article_xml(xml_file):
             return ElementTree.fromstring(xml_string)
         except ElementTree.ParseError:
             # try to repair the xml namespaces
-            xml_string = xml_string.replace(
-                '<article article-type="research-article">',
-                (
-                    '<article article-type="research-article" '
-                    'xmlns:xlink="http://www.w3.org/1999/xlink">'
-                ),
-            )
+            xml_string = repair_article_xml(xml_string)
             return ElementTree.fromstring(xml_string)
+
+
+def repair_article_xml(xml_string):
+    if 'xmlns:xlink="http://www.w3.org/1999/xlink"' not in xml_string:
+        return re.sub(
+            r"<article(.*?)>",
+            r'<article\1 xmlns:xlink="http://www.w3.org/1999/xlink">',
+            xml_string,
+        )
+    return xml_string
 
 
 def file_list(root):

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -1,6 +1,7 @@
 import re
 from collections import OrderedDict
 from xml.etree import ElementTree
+import html
 from wand.image import Image
 from wand.exceptions import PolicyError, WandRuntimeError
 from elifecleaner import LOGGER, zip_lib
@@ -36,6 +37,8 @@ def article_xml_asset(asset_file_name_map):
 def parse_article_xml(xml_file):
     with open(xml_file, "r") as open_file:
         xml_string = open_file.read()
+        # unescape any HTML entities to avoid undefined entity XML exceptions later
+        xml_string = html.unescape(xml_string)
         try:
             return ElementTree.fromstring(xml_string)
         except ElementTree.ParseError:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -43,20 +43,6 @@ class TestParse(unittest.TestCase):
         xml_asset = parse.article_xml_asset(asset_file_name_map)
         self.assertEqual(xml_asset, expected)
 
-    def test_parse_article_xml(self):
-        xml_file_path = os.path.join(self.temp_dir, "test.xml")
-        with open(xml_file_path, "w") as open_file:
-            open_file.write("<article/>")
-        root = parse.parse_article_xml(xml_file_path)
-        self.assertIsNotNone(root)
-
-    def test_parse_article_xml_failure(self):
-        xml_file_path = os.path.join(self.temp_dir, "test.xml")
-        with open(xml_file_path, "w") as open_file:
-            open_file.write("malformed xml")
-        with self.assertRaises(ElementTree.ParseError):
-            parse.parse_article_xml(xml_file_path)
-
     def test_file_list(self):
         zip_file = "tests/test_data/30-01-2019-RA-eLife-45644.zip"
         asset_file_name_map = zip_lib.unzip_zip(zip_file, self.temp_dir)
@@ -112,6 +98,35 @@ class TestParse(unittest.TestCase):
                     "imagemagick policy.xml may not allow reading PDF files\n"
                 ),
             )
+
+
+class TestParseArticleXML(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+
+    def tearDown(self):
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_parse_article_xml(self):
+        xml_file_path = os.path.join(self.temp_dir, "test.xml")
+        with open(xml_file_path, "w") as open_file:
+            open_file.write("<article/>")
+        root = parse.parse_article_xml(xml_file_path)
+        self.assertIsNotNone(root)
+
+    def test_parse_article_xml_entities(self):
+        xml_file_path = os.path.join(self.temp_dir, "test.xml")
+        with open(xml_file_path, "w") as open_file:
+            open_file.write("<article>&mdash;</article>")
+        root = parse.parse_article_xml(xml_file_path)
+        self.assertIsNotNone(root)
+
+    def test_parse_article_xml_failure(self):
+        xml_file_path = os.path.join(self.temp_dir, "test.xml")
+        with open(xml_file_path, "w") as open_file:
+            open_file.write("malformed xml")
+        with self.assertRaises(ElementTree.ParseError):
+            parse.parse_article_xml(xml_file_path)
 
 
 class TestRepairArticleXml(unittest.TestCase):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -112,3 +112,36 @@ class TestParse(unittest.TestCase):
                     "imagemagick policy.xml may not allow reading PDF files\n"
                 ),
             )
+
+
+class TestRepairArticleXml(unittest.TestCase):
+    def test_malformed_xml(self):
+        xml_string = "malformed xml"
+        expected = "malformed xml"
+        self.assertEqual(parse.repair_article_xml(xml_string), expected)
+
+    def test_research_article(self):
+        xml_string = '<article article-type="research-article"></article>'
+        expected = (
+            '<article article-type="research-article" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink"></article>'
+        )
+        self.assertEqual(parse.repair_article_xml(xml_string), expected)
+
+    def test_article_commentary(self):
+        xml_string = '<article article-type="article-commentary"></article>'
+        expected = (
+            '<article article-type="article-commentary" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink"></article>'
+        )
+        self.assertEqual(parse.repair_article_xml(xml_string), expected)
+
+    def test_article_tag(self):
+        xml_string = "<article></article>"
+        expected = '<article xmlns:xlink="http://www.w3.org/1999/xlink"></article>'
+        self.assertEqual(parse.repair_article_xml(xml_string), expected)
+
+    def test_xlink_namespace_already_exists(self):
+        xml_string = '<article xmlns:xlink="http://www.w3.org/1999/xlink"></article>'
+        expected = '<article xmlns:xlink="http://www.w3.org/1999/xlink"></article>'
+        self.assertEqual(parse.repair_article_xml(xml_string), expected)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -118,8 +118,10 @@ class TestParseArticleXML(unittest.TestCase):
         xml_file_path = os.path.join(self.temp_dir, "test.xml")
         with open(xml_file_path, "w") as open_file:
             open_file.write("<article>&mdash;</article>")
+        expected = b"<article>&#8212;</article>"
         root = parse.parse_article_xml(xml_file_path)
         self.assertIsNotNone(root)
+        self.assertEqual(ElementTree.tostring(root), expected)
 
     def test_parse_article_xml_failure(self):
         xml_file_path = os.path.join(self.temp_dir, "test.xml")


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6376

When testing on real data, XML parsing exceptions were raised. This will fix two things,

- Repair the `<article>` tag namespaces in more varied situations by using a regular expression substitution
- An XML file had an `&mdash;` entity which the XML parser cannot handle, so use `html. unescape()` to convert these types of entities before parsing it as XML