### PR TITLE
Bug fix regex in repair_article_xml()

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -225,9 +225,10 @@ def html_entity_unescape(xml_string):
 
 def repair_article_xml(xml_string):
     if 'xmlns:xlink="http://www.w3.org/1999/xlink"' not in xml_string:
-        return re.sub(
-            r"<article(.*?)>",
-            r'<article\1 xmlns:xlink="http://www.w3.org/1999/xlink">',
+        article_match_pattern = re.compile(r"<article>|<article(\s{1,}.*?)>")
+        replacement_pattern = r'<article\1 xmlns:xlink="http://www.w3.org/1999/xlink">'
+        return article_match_pattern.sub(
+            replacement_pattern,
             xml_string,
         )
     return xml_string

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -284,6 +284,18 @@ class TestRepairArticleXml(unittest.TestCase):
         expected = '<article xmlns:xlink="http://www.w3.org/1999/xlink"></article>'
         self.assertEqual(parse.repair_article_xml(xml_string), expected)
 
+    def test_artice_id_tag(self):
+        # do not add to <article-id> tags
+        xml_string = (
+            '<article article-type="research-article"></article>'
+            '<article-id pub-id-type="publisher-id">45644</article-id>'
+        )
+        expected = (
+            '<article article-type="research-article" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '</article><article-id pub-id-type="publisher-id">45644</article-id>'
+        )
+        self.assertEqual(parse.repair_article_xml(xml_string), expected)
+
 
 class TestFindMissingFiles(unittest.TestCase):
     def test_find_missing_files_complete(self):


### PR DESCRIPTION
When using some of the repaired XML output, I noticed the XML namespaces were being added to the `<article-id>` tags as well as the (only) intended `<article>` tag. Here is an improved regular expression replacement, accompanied by another test scenario. There were no bugs as a result of this, it just makes the repaired XML a little more precise.