### PR TITLE
Zip code files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tmp/*
 !tmp/.keepme
 tests/tmp/*
 !tests/tmp/.keepme
+tests/tmp_output/*
+!tests/tmp_output/.keepme

--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/transform.py
+++ b/elifecleaner/transform.py
@@ -1,0 +1,163 @@
+import copy
+import os
+import zipfile
+from elifetools import xmlio
+from elifecleaner import LOGGER, parse, zip_lib
+
+
+class ArticleZipFile:
+    "data structure for holding details about files in a zip with a manifest XML"
+
+    def __init__(self, xml_name=None, zip_name=None, file_path=None):
+        self.xml_name = xml_name
+        self.zip_name = zip_name
+        self.file_path = file_path
+
+    def __repr__(self):
+        return 'ArticleZipFile("%s", "%s", "%s")' % (
+            self.xml_name,
+            self.zip_name,
+            self.file_path,
+        )
+
+
+def transform_ejp_zip(zip_file, tmp_dir, output_dir):
+    "transform ejp zip file and write a new zip file output"
+
+    new_zip_file_path = None
+    zip_file_name = zip_file.split(os.sep)[-1]
+
+    # start logging
+    LOGGER.info("%s starting to transform", zip_file_name)
+
+    # profile the zip contents
+    asset_file_name_map = zip_lib.unzip_zip(zip_file, tmp_dir)
+    xml_asset = parse.article_xml_asset(asset_file_name_map)
+    xml_asset_path = xml_asset[1]
+    root = parse.parse_article_xml(xml_asset_path)
+
+    code_files = code_file_list(root)
+
+    # zip code files
+    file_transformations = []
+    for file_data in code_files:
+        code_file_name = file_data.get("upload_file_nm")
+
+        LOGGER.info("%s code_file_name: %s" % (zip_file_name, code_file_name))
+        # collect file name data
+        original_code_file_name, original_code_file_path = find_in_file_name_map(
+            code_file_name, asset_file_name_map
+        )
+
+        from_file = ArticleZipFile(
+            code_file_name, original_code_file_name, original_code_file_path
+        )
+        LOGGER.info("%s from_file: %s" % (zip_file_name, from_file))
+
+        to_file = zip_code_file(from_file, output_dir)
+        LOGGER.info("%s to_file: %s" % (zip_file_name, to_file))
+
+        # save the from file to file transformation
+        file_transformations.append((from_file, to_file))
+
+    # rewrite the XML tags
+    LOGGER.info("%s rewriting xml tags" % zip_file_name)
+    root = transform_xml_file_tags(root, file_transformations)
+
+    # write new XML file
+    xml_string = xml_element_to_string(root)
+    LOGGER.info("%s writing xml to file %s" % (zip_file_name, xml_asset_path))
+    with open(xml_asset_path, "w") as open_file:
+        open_file.write(xml_string)
+
+    # create a new asset map
+    new_asset_file_name_map = transform_asset_file_name_map(
+        asset_file_name_map, file_transformations
+    )
+
+    # write new zip file
+    new_zip_file_path = os.path.join(output_dir, zip_file_name)
+    LOGGER.info("%s writing new zip file %s" % (zip_file_name, new_zip_file_path))
+    create_zip_from_file_map(new_zip_file_path, new_asset_file_name_map)
+
+    return new_zip_file_path
+
+
+def xml_element_to_string(root):
+    xmlio.register_xmlns()
+    return xmlio.output_root(root, None, None)
+
+
+def code_file_list(root):
+    code_files = []
+
+    files = parse.file_list(root)
+
+    aux_files = [
+        file_data for file_data in files if file_data.get("file_type") == "aux_file"
+    ]
+
+    for file_data in aux_files:
+        if file_data.get("upload_file_nm").endswith(".zip"):
+            # if it is already a zip file, skip it
+            continue
+        code_files.append(file_data)
+
+    return code_files
+
+
+def find_in_file_name_map(file_name, file_name_map):
+    for asset_file_name, file_name_path in file_name_map.items():
+        if file_name_path.endswith(file_name):
+            return asset_file_name, file_name_path
+    return None, None
+
+
+def zip_code_file(from_file, output_dir):
+    "zip a code file and put new zip details into an ArticleZipFile struct"
+    code_file_zip_name = from_file.zip_name + ".zip"
+    new_code_file_name = from_file.xml_name + ".zip"
+    code_file_zip_path = os.path.join(output_dir, new_code_file_name)
+
+    to_file = ArticleZipFile(new_code_file_name, code_file_zip_name, code_file_zip_path)
+
+    with zipfile.ZipFile(code_file_zip_path, "w") as open_zipfile:
+        open_zipfile.write(from_file.file_path, from_file.zip_name)
+
+    return to_file
+
+
+def from_file_to_file_map(file_transformations):
+    "convert a list of file transformations into a dict keyed on their xml file name"
+    return {
+        from_file.xml_name: to_file.xml_name
+        for from_file, to_file in file_transformations
+    }
+
+
+def transform_xml_file_tags(root, file_transformations):
+    "replace file name tags in xml Element with names from file transformations list"
+    xml_file_name_transforms = from_file_to_file_map(file_transformations)
+    for file_nm_tag in root.findall("./front/article-meta/files/file/upload_file_nm"):
+        if file_nm_tag.text in xml_file_name_transforms:
+            file_nm_tag.text = xml_file_name_transforms.get(file_nm_tag.text)
+    return root
+
+
+def transform_asset_file_name_map(asset_file_name_map, file_transformations):
+    "replace file name details in the map with those from the list of file transformations"
+    new_asset_file_name_map = copy.copy(asset_file_name_map)
+    for from_file, to_file in file_transformations:
+        if from_file.zip_name in new_asset_file_name_map:
+            del new_asset_file_name_map[from_file.zip_name]
+            new_asset_file_name_map[to_file.zip_name] = to_file.file_path
+    return new_asset_file_name_map
+
+
+def create_zip_from_file_map(zip_path, file_name_map):
+    "write the files to a zip"
+    with zipfile.ZipFile(
+        zip_path, "w", zipfile.ZIP_DEFLATED, allowZip64=True
+    ) as open_zip:
+        for file_name, file_path in file_name_map.items():
+            open_zip.write(file_path, file_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pytest==6.2.2
+elifetools==0.12.0
 mock==4.0.3
+pytest==6.2.2
 Wand==0.6.6

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=["elifecleaner"],
     license="MIT",
-    install_requires=["wand >= 0.5.2"],
+    install_requires=["elifetools", "wand >= 0.5.2"],
     url="https://github.com/elifesciences/elife-cleaner",
     maintainer="eLife Sciences Publications Ltd.",
     maintainer_email="tech-team@elifesciences.org",

--- a/tests/fixtures/code_file_list.py
+++ b/tests/fixtures/code_file_list.py
@@ -1,0 +1,41 @@
+from collections import OrderedDict
+
+
+EXPECTED = [
+    OrderedDict(
+        [
+            ("file_type", "aux_file"),
+            ("id", "1119366"),
+            ("upload_file_nm", "Figure 5source code 1.c"),
+            (
+                "custom_meta",
+                [
+                    OrderedDict(
+                        [
+                            ("meta_name", "Title"),
+                            ("meta_value", "Figure 5-source code 1"),
+                        ]
+                    )
+                ],
+            ),
+        ]
+    ),
+    OrderedDict(
+        [
+            ("file_type", "aux_file"),
+            ("id", None),
+            ("upload_file_nm", "Figure 5source code 2.c"),
+            (
+                "custom_meta",
+                [
+                    OrderedDict(
+                        [
+                            ("meta_name", "Title"),
+                            ("meta_value", "Figure 5-source code 2"),
+                        ]
+                    )
+                ],
+            ),
+        ]
+    ),
+]

--- a/tests/fixtures/code_file_list.xml
+++ b/tests/fixtures/code_file_list.xml
@@ -1,0 +1,44 @@
+<article>
+    <front>
+        <article-meta>
+            <files>
+                <file file-type='figure' id='1119351'>
+                    <upload_file_nm>Figure 5.png</upload_file_nm>
+                    <order>1</order>
+                    <size units='bytes'>129684</size>
+                    <custom-meta>
+                        <meta-name>Figure number</meta-name>
+                        <meta-value>Figure 5</meta-value>
+                    </custom-meta>
+                </file>
+                <file file-type='aux_file' id='1119366'>
+                    <upload_file_nm>Figure 5source code 1.c</upload_file_nm>
+                    <order>2</order>
+                    <size units='bytes'>11193</size>
+                    <custom-meta>
+                        <meta-name>Title</meta-name>
+                        <meta-value>Figure 5-source code 1</meta-value>
+                    </custom-meta>
+                </file>
+                <file file-type='aux_file'>
+                    <upload_file_nm>Figure 5source code 2.c</upload_file_nm>
+                    <order>2</order>
+                    <size units='bytes'>11193</size>
+                    <custom-meta>
+                        <meta-name>Title</meta-name>
+                        <meta-value>Figure 5-source code 2</meta-value>
+                    </custom-meta>
+                </file>
+                <file file-type='aux_file'>
+                    <upload_file_nm>Figure 5source code 3.c.zip</upload_file_nm>
+                    <order>3</order>
+                    <size units='bytes'>11193</size>
+                    <custom-meta>
+                        <meta-name>Title</meta-name>
+                        <meta-value>Figure 5-source code 3</meta-value>
+                    </custom-meta>
+                </file>
+            </files>
+        </article-meta>
+    </front>
+</article>

--- a/tests/test_data/main.c
+++ b/tests/test_data/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main() {
+   printf("Hello, World!");
+   return 0;
+}

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,349 @@
+import io
+import os
+import unittest
+import zipfile
+from xml.etree import ElementTree
+from elifecleaner import LOGGER, configure_logging, transform
+from elifecleaner.transform import ArticleZipFile
+from tests.helpers import delete_files_in_folder, read_fixture
+
+
+class TestArticleZipFile(unittest.TestCase):
+    def test_instantiate(self):
+        xml_name = "sub_folder/file.txt"
+        zip_name = "file.txt"
+        file_path = "local_folder/sub_folder/file.txt"
+        from_file = ArticleZipFile(xml_name, zip_name, file_path)
+        expected = 'ArticleZipFile("%s", "%s", "%s")' % (xml_name, zip_name, file_path)
+        self.assertEqual(str(from_file), expected)
+
+
+class TestTransform(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+        self.output_dir = "tests/tmp_output"
+        self.log_file = os.path.join(self.temp_dir, "test.log")
+        self.log_handler = configure_logging(self.log_file)
+
+    def tearDown(self):
+        LOGGER.removeHandler(self.log_handler)
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+        delete_files_in_folder(self.output_dir, filter_out=[".keepme"])
+
+    def test_transform_ejp_zip(self):
+        zip_file = "tests/test_data/30-01-2019-RA-eLife-45644.zip"
+        zip_file_name = zip_file.split(os.sep)[-1]
+        info_prefix = (
+            "INFO elifecleaner:transform:transform_ejp_zip: %s"
+        ) % zip_file_name
+        expected_new_zip_file_path = os.path.join(self.output_dir, zip_file_name)
+        new_zip_file_path = transform.transform_ejp_zip(
+            zip_file, self.temp_dir, self.output_dir
+        )
+        self.assertEqual(new_zip_file_path, expected_new_zip_file_path)
+        log_file_lines = []
+        with open(self.log_file, "r") as open_file:
+            for line in open_file:
+                log_file_lines.append(line)
+
+        self.assertEqual(log_file_lines[0], "%s starting to transform\n" % info_prefix)
+
+        self.assertEqual(
+            log_file_lines[1],
+            "%s code_file_name: Figure 5source code 1.c\n" % info_prefix,
+        )
+        self.assertEqual(
+            log_file_lines[2],
+            (
+                '%s from_file: ArticleZipFile("Figure 5source code 1.c",'
+                ' "30-01-2019-RA-eLife-45644/Figure 5source code 1.c",'
+                ' "tests/tmp/30-01-2019-RA-eLife-45644/Figure 5source code 1.c")\n'
+            )
+            % info_prefix,
+        )
+
+        self.assertEqual(
+            log_file_lines[3],
+            (
+                '%s to_file: ArticleZipFile("Figure 5source code 1.c.zip",'
+                ' "30-01-2019-RA-eLife-45644/Figure 5source code 1.c.zip",'
+                ' "tests/tmp_output/Figure 5source code 1.c.zip")\n'
+            )
+            % info_prefix,
+        )
+        self.assertEqual(log_file_lines[4], "%s rewriting xml tags\n" % info_prefix)
+        self.assertEqual(
+            log_file_lines[5],
+            (
+                "%s writing xml to file"
+                " tests/tmp/30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml\n"
+            )
+            % info_prefix,
+        )
+        self.assertEqual(
+            log_file_lines[6],
+            (
+                "%s writing new zip file"
+                " tests/tmp_output/30-01-2019-RA-eLife-45644.zip\n"
+            )
+            % info_prefix,
+        )
+        # check output directory contents
+        output_dir_list = os.listdir(self.output_dir)
+        self.assertTrue("30-01-2019-RA-eLife-45644.zip" in output_dir_list)
+        self.assertTrue("Figure 5source code 1.c.zip" in output_dir_list)
+
+        # check zip file contents
+        expected_infolist_filenames = [
+            "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.pdf",
+            "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml",
+            "30-01-2019-RA-eLife-45644/Answers for the eLife digest.docx",
+            "30-01-2019-RA-eLife-45644/Appendix 1.docx",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 1.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 10.pdf",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 11.pdf",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 12.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 13.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 14.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 15.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 2.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 3.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 4.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 5.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 6.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 7.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 8.png",
+            "30-01-2019-RA-eLife-45644/Appendix 1figure 9.png",
+            "30-01-2019-RA-eLife-45644/Figure 1.tif",
+            "30-01-2019-RA-eLife-45644/Figure 2.tif",
+            "30-01-2019-RA-eLife-45644/Figure 3.png",
+            "30-01-2019-RA-eLife-45644/Figure 4.svg",
+            "30-01-2019-RA-eLife-45644/Figure 4source data 1.zip",
+            "30-01-2019-RA-eLife-45644/Figure 5.png",
+            "30-01-2019-RA-eLife-45644/Figure 5source code 1.c.zip",
+            "30-01-2019-RA-eLife-45644/Figure 6.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 10_HorC.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 1_U crassus.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 2_U pictorum.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 3_M margaritifera.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 4_P auricularius.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 5_PesB.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 6_HavA.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 7_HavB.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 8_HavC.png",
+            "30-01-2019-RA-eLife-45644/Figure 6figure supplement 9_HorB.png",
+            "30-01-2019-RA-eLife-45644/Figure 6source data 1.pdf",
+            "30-01-2019-RA-eLife-45644/Manuscript.docx",
+            "30-01-2019-RA-eLife-45644/Potential striking image.tif",
+            "30-01-2019-RA-eLife-45644/Table 2source data 1.xlsx",
+            "30-01-2019-RA-eLife-45644/transparent_reporting_Sakalauskaite.docx",
+        ]
+        with zipfile.ZipFile(new_zip_file_path, "r") as open_zipfile:
+            infolist = open_zipfile.infolist()
+        infolist_filenames = sorted(
+            [info.filename for info in infolist if info.filename != ".keepme"]
+        )
+        self.assertEqual(infolist_filenames, expected_infolist_filenames)
+
+        # assertions on XML file contents
+        with zipfile.ZipFile(new_zip_file_path, "r") as open_zipfile:
+            article_xml = open_zipfile.read(
+                "30-01-2019-RA-eLife-45644/30-01-2019-RA-eLife-45644.xml"
+            )
+        self.assertTrue(
+            b"<upload_file_nm>Figure 5source code 1.c.zip</upload_file_nm>"
+            in article_xml
+        )
+        self.assertTrue(
+            b"<upload_file_nm>Figure 5source code 1.c</upload_file_nm>"
+            not in article_xml
+        )
+
+        # assertions on code zip file contents
+        with zipfile.ZipFile(new_zip_file_path, "r") as open_zipfile:
+            code_zip = open_zipfile.read(
+                "30-01-2019-RA-eLife-45644/Figure 5source code 1.c.zip"
+            )
+        file_like_object = io.BytesIO(code_zip)
+        with zipfile.ZipFile(file_like_object, "r") as open_zipfile:
+            infolist = open_zipfile.infolist()
+        self.assertEqual(
+            [info.filename for info in infolist],
+            ["30-01-2019-RA-eLife-45644/Figure 5source code 1.c"],
+        )
+        # self.assertTrue(False)
+
+
+class TestXmlElementToString(unittest.TestCase):
+    def test_xml_element_to_string(self):
+        xml_string = (
+            '<article article-type="research-article"'
+            ' xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<front><article-meta><permissions>"
+            '<license license-type="open-access"'
+            ' xlink:href="http://creativecommons.org/licenses/by/4.0/"/>'
+            "</permissions></article-meta></front>"
+            "</article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        expected = '<?xml version="1.0" ?>%s' % xml_string
+        self.assertEqual(transform.xml_element_to_string(root), expected)
+
+
+class TestCodeFileList(unittest.TestCase):
+    def test_code_file_list(self):
+        xml_string = read_fixture("code_file_list.xml")
+        expected = read_fixture("code_file_list.py")
+        root = ElementTree.fromstring(xml_string)
+        code_files = transform.code_file_list(root)
+        self.assertEqual(code_files, expected)
+
+
+class TestFindInFileNameMap(unittest.TestCase):
+    def test_find_in_file_name_map(self):
+        file_name = "file_one.txt"
+        asset_file_name = "zip_sub_folder/file_one.txt"
+        file_path = "local_folder/zip_sub_folder/file_one.txt"
+        file_name_map = {asset_file_name: file_path}
+        expected = (asset_file_name, file_path)
+        self.assertEqual(
+            transform.find_in_file_name_map(file_name, file_name_map), expected
+        )
+
+    def test_find_in_file_name_map_not_found(self):
+        file_name = "file_one.txt"
+        file_name_map = {}
+        expected = (None, None)
+        self.assertEqual(
+            transform.find_in_file_name_map(file_name, file_name_map), expected
+        )
+
+
+class TestZipCodeFile(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+
+    def tearDown(self):
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_zip_code_file(self):
+        file_name = "main.c"
+        from_file = ArticleZipFile(
+            file_name, "zip_folder/%s" % file_name, "tests/test_data/%s" % file_name
+        )
+        expected = ArticleZipFile(
+            "%s.zip" % file_name,
+            "zip_folder/%s.zip" % file_name,
+            "%s/%s.zip" % (self.temp_dir, file_name),
+        )
+        to_file = transform.zip_code_file(from_file, self.temp_dir)
+        # compare ArticleZipFile representation by casting them to str
+        self.assertEqual(str(to_file), str(expected))
+
+
+class TestFromFileToFileMap(unittest.TestCase):
+    def test_from_file_to_file_map(self):
+        from_xml_name = "source.c"
+        to_xml_name = "source.c.zip"
+        from_file = ArticleZipFile(from_xml_name, None, None)
+        to_file = ArticleZipFile(to_xml_name, None, None)
+        file_transformations = [(from_file, to_file)]
+        expected = {from_xml_name: to_xml_name}
+        self.assertEqual(
+            transform.from_file_to_file_map(file_transformations), expected
+        )
+
+
+class TestTransformXmlFileTags(unittest.TestCase):
+    def test_transform_xml_file_tags(self):
+        # populate an ElementTree
+        xml_string = read_fixture("code_file_list.xml")
+        root = ElementTree.fromstring(xml_string)
+        # specify from file, to file transformations
+        file_transformations = []
+        test_data = [
+            {
+                "from_xml": "Figure 5source code 1.c",
+                "to_xml": "Figure 5source code 1.c.zip",
+            },
+            {
+                "from_xml": "Figure 5source code 2.c",
+                "to_xml": "Figure 5source code 2.c.zip",
+            },
+        ]
+        for data in test_data:
+            from_file = ArticleZipFile(data.get("from_xml"), None, None)
+            to_file = ArticleZipFile(data.get("to_xml"), None, None)
+            file_transformations.append((from_file, to_file))
+        # invoke the function
+        root_output = transform.transform_xml_file_tags(root, file_transformations)
+        # find the tag in the XML root returned which will have been altered
+        upload_file_nm_tags = root_output.findall(
+            "./front/article-meta/files/file/upload_file_nm"
+        )
+        # assert the XML text is different
+        self.assertEqual(upload_file_nm_tags[1].text, test_data[0].get("to_xml"))
+        self.assertEqual(upload_file_nm_tags[2].text, test_data[1].get("to_xml"))
+
+
+class TestTransformAssetFileNameMap(unittest.TestCase):
+    def test_transform_asset_file_name_map_empty(self):
+        # test empty arguments
+        asset_file_name_map = {}
+        file_transformations = []
+        expected = {}
+        new_asset_file_name_map = transform.transform_asset_file_name_map(
+            asset_file_name_map, file_transformations
+        )
+        self.assertEqual(new_asset_file_name_map, expected)
+
+    def test_transform_asset_file_name_map(self):
+        # test one file example
+        asset_file_name_map = {"zip_folder/main.c": "local_folder/zip_folder/main.c"}
+        from_file = ArticleZipFile(
+            "main.c", "zip_folder/main.c", "local_folder/zip_folder/main.c"
+        )
+        to_file = ArticleZipFile(
+            "main.c.zip", "zip_folder/main.c.zip", "tmp_folder/zip_folder/main.c.zip"
+        )
+        file_transformations = [(from_file, to_file)]
+        expected = {"zip_folder/main.c.zip": "tmp_folder/zip_folder/main.c.zip"}
+        new_asset_file_name_map = transform.transform_asset_file_name_map(
+            asset_file_name_map, file_transformations
+        )
+        self.assertEqual(new_asset_file_name_map, expected)
+
+    def test_transform_asset_file_name_map_mismatch(self):
+        # test if from_file is not found in the name map
+        asset_file_name_map = {}
+        from_file = ArticleZipFile(
+            "main.c", "zip_folder/main.c", "local_folder/zip_folder/main.c"
+        )
+        to_file = ArticleZipFile(
+            "main.c.zip", "zip_folder/main.c.zip", "tmp_folder/zip_folder/main.c.zip"
+        )
+        file_transformations = [(from_file, to_file)]
+        expected = {}
+        new_asset_file_name_map = transform.transform_asset_file_name_map(
+            asset_file_name_map, file_transformations
+        )
+        self.assertEqual(new_asset_file_name_map, expected)
+
+
+class TestCreateZipFromFileMap(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+
+    def tearDown(self):
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_create_zip_from_file_map(self):
+        zip_path = os.path.join(self.temp_dir, "test.zip")
+        # add a file from the test data
+        file_name = "zip_folder/main.c"
+        file_path = "tests/test_data/main.c"
+        file_name_map = {file_name: file_path}
+        transform.create_zip_from_file_map(zip_path, file_name_map)
+        with zipfile.ZipFile(zip_path, "r") as open_zipfile:
+            infolist = open_zipfile.infolist()
+        self.assertEqual(infolist[0].filename, file_name)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7000

The first modification to an accepted submission is to zip any source code files that are not already in a zip file. A new module `transform.py` is added to this library to contain the logic. `elifetools` is added as a library dependency in order to use its function for writing an `ElementTree` to an XML string while retaining commonly used JATS XML namespaces.

A new version of `0.6.0` is assigned to this enhancement.