### PR TITLE
Add REPAIR_XML flag so it can be configured.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -8,6 +8,10 @@ from wand.exceptions import PolicyError, WandRuntimeError
 from elifecleaner import LOGGER, zip_lib
 
 
+# flag for whether to try and repair XML if it encounters a ParseError
+REPAIR_XML = True
+
+
 def check_ejp_zip(zip_file, tmp_dir):
     "check contents of ejp zip file"
     asset_file_name_map = zip_lib.unzip_zip(zip_file, tmp_dir)
@@ -196,9 +200,13 @@ def parse_article_xml(xml_file):
         try:
             return ElementTree.fromstring(xml_string)
         except ElementTree.ParseError:
-            # try to repair the xml namespaces
-            xml_string = repair_article_xml(xml_string)
-            return ElementTree.fromstring(xml_string)
+            if REPAIR_XML:
+                # try to repair the xml namespaces
+                xml_string = repair_article_xml(xml_string)
+                return ElementTree.fromstring(xml_string)
+            else:
+                LOGGER.exception("ParseError raised because REPAIR_XML flag is False")
+                raise
 
 
 def replace_entity(match):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7062

By default, an attempt to repair malformed XML will be done if a `ParseError` exception is raised. However, recently some changes are expected to make it so the XML supplied will no longer be malformed. Added to the `parse` module is a constant flag named `REPAIR_XML`, which will allow the XML repair to be disabled in particular situations where we want to check if the XML is actually not malformed.

Bumping the library version to `0.7.0` with this enhancement.