### PR TITLE
Enhance PDF check with pdfimages utility.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/pdf_utils.py
+++ b/elifecleaner/pdf_utils.py
@@ -1,0 +1,34 @@
+import re
+import shutil
+import subprocess
+
+
+def pdfimages_exists():
+    "check if pdfimages exists"
+    return shutil.which("pdfimages")
+
+
+def pdfimages_output(pdf):
+    "invoke pdfimages utility"
+    return subprocess.run(
+        ["pdfimages", "-list", pdf],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def pdf_image_pages(pdf):
+    "return pdf pages on which images are found from pdfimages output"
+    result = pdfimages_output(pdf)
+    page_list = []
+    if result.stdout:
+        page_line_match_pattern = re.compile(r"\s+(\d+)\s.*")
+        output_lines = str(result.stdout, encoding="utf8").split("\n")
+        if output_lines and output_lines[0].startswith("page "):
+            for line in output_lines:
+                match_result = re.match(page_line_match_pattern, line)
+                if match_result:
+                    page_list.append(int(match_result.group(1)))
+    # de-dupe page list into a set of unique values
+    return set(page_list)

--- a/tests/test_pdf_utils.py
+++ b/tests/test_pdf_utils.py
@@ -1,0 +1,72 @@
+import os
+import unittest
+from mock import patch
+from elifecleaner import pdf_utils, zip_lib
+from tests.helpers import delete_files_in_folder
+
+PDFIMAGES_OUTPUT = (
+    b"page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio\n"
+    b"--------------------------------------------------------------------------------------------\n"
+    b"   1     0 image    1254  2131  rgb     3   8  image  no         9  0   220   220  139K 1.8%\n"
+    b"   2     1 image    1314   358  rgb     3   8  image  no        12  0   223   222 18.0K 1.3%\n"
+    b"   2     2 image    1324   361  rgb     3   8  image  no        13  0   224   224 21.0K 1.5%\n"
+    b"   2     3 image    1319   360  rgb     3   8  image  no        14  0   223   224 21.5K 1.5%\n"
+    b"   2     4 image    1319   360  rgb     3   8  image  no        15  0   223   224 19.0K 1.4%\n"
+    b"   2     5 image    1314   358  rgb     3   8  image  no        16  0   223   222 18.5K 1.3%\n"
+    b"   3     6 image    1321   360  rgb     3   8  image  no        19  0   224   223 23.5K 1.7%\n"
+    b"   3     7 image    1328   362  rgb     3   8  image  no        20  0   225   225 23.5K 1.7%\n"
+    b"   3     8 image    1328   362  rgb     3   8  image  no        21  0   225   225 20.8K 1.5%\n"
+    b"   3     9 image    1324   361  rgb     3   8  image  no        22  0   224   224 21.9K 1.6%\n"
+    b"   3    10 image    1328   362  rgb     3   8  image  no        23  0   225   225 23.9K 1.7%\n"
+    b"   4    11 image    1330   363  rgb     3   8  image  no        26  0   225   225 21.5K 1.5%\n"
+    b"   4    12 image    1326   362  rgb     3   8  image  no        27  0   225   225 24.9K 1.8%\n"
+    b"   4    13 image    1326   362  rgb     3   8  image  no        28  0   225   225 26.3K 1.9%\n"
+    b"   4    14 image    1331   360  rgb     3   8  image  no        29  0   225   225 29.7K 2.1%\n"
+    b"   4    15 image    1330   363  rgb     3   8  image  no        30  0   225   225 24.2K 1.7%\n"
+    b"   5    16 image    1321   360  rgb     3   8  image  no        33  0   224   223 25.0K 1.8%\n"
+    b"   5    17 image    1312   358  rgb     3   8  image  no        34  0   222   222 23.6K 1.7%\n"
+    b"   5    18 image    1328   362  rgb     3   8  image  no        35  0   225   225 25.0K 1.8%\n"
+    b"   5    19 image    1324   361  rgb     3   8  image  no        36  0   224   224 23.1K 1.6%\n"
+    b"   5    20 image    1307   356  rgb     3   8  image  no        37  0   221   221 26.1K 1.9%\n"
+    b"   6    21 image    1322   358  rgb     3   8  image  no        40  0   220   220 26.6K 1.9%\n"
+    b"   6    22 image    1300   352  rgb     3   8  image  no        41  0   220   220 23.6K 1.8%\n"
+    b"   6    23 image    1300   352  rgb     3   8  image  no        42  0   220   220 35.3K 2.6%\n"
+    b"   6    24 image    1300   352  rgb     3   8  image  no        43  0   220   220 20.0K 1.5%\n"
+    b"   6    25 image    1300   352  rgb     3   8  image  no        44  0   220   220 29.6K 2.2%\n"
+)
+
+
+class Result:
+    "struct for testing"
+
+    def __init__(self):
+        self.stdout = None
+
+
+class TestPdfImagePages(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+
+    def tearDown(self):
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_pdfimages_output(self):
+        zip_file = "tests/test_data/30-01-2019-RA-eLife-45644.zip"
+        zip_lib.unzip_zip(zip_file, self.temp_dir)
+        # run only if pdfimages is available
+        if pdf_utils.pdfimages_exists():
+            pdf_file = os.path.join(
+                self.temp_dir, "30-01-2019-RA-eLife-45644/Appendix 1figure 10.pdf"
+            )
+            result = pdf_utils.pdfimages_output(pdf_file)
+            self.assertIsNotNone(result.stdout)
+
+    @patch.object(pdf_utils, "pdfimages_output")
+    def test_pdf_image_pages(self, mock_pdfimages_output):
+        mock_result = Result()
+        mock_result.stdout = PDFIMAGES_OUTPUT
+        mock_pdfimages_output.return_value = mock_result
+        expected = {1, 2, 3, 4, 5, 6}
+        pdf_file = "figure.pdf"
+        pages = pdf_utils.pdf_image_pages(pdf_file)
+        self.assertEqual(pages, expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6376

If available, invoke `pdfimages` to get more detailed data about multi-page figure PDF files to check whether any images appear on pages two or greater. If there's a run-time exception, or if `pdfimages` is not available to use, the checking logic will rely on the page count of the PDF to determine a multi-page figure PDF warning message.

Setting the library version `0.8.0` for this enhancement.