### PR TITLE
Fix using pdfimages for checking multi-page PDF.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -59,7 +59,13 @@ def check_multi_page_figure_pdf(figures, zip_file_name):
                 pdf.get("file_name"),
             )
             try:
-                image_pages = pdf_utils.pdf_image_pages(pdf.get("file_name"))
+                image_pages = pdf_utils.pdf_image_pages(pdf.get("file_path"))
+                LOGGER.info(
+                    "%s pdfimages found images on pages %s in PDF figure file: %s",
+                    zip_file_name,
+                    image_pages,
+                    pdf.get("file_name"),
+                )
                 is_multi_page = bool([page for page in image_pages if page > 1])
             except:
                 LOGGER.exception(
@@ -67,7 +73,7 @@ def check_multi_page_figure_pdf(figures, zip_file_name):
                     zip_file_name,
                     pdf.get("file_name"),
                 )
-            finally:
+                # consider it multi page in the case pdfimages raises an exception
                 is_multi_page = True
         else:
             is_multi_page = True

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -25,7 +25,7 @@ class TestParse(unittest.TestCase):
     @patch.object(pdf_utils, "pdfimages_exists")
     def test_check_ejp_zip(self, mock_pdfimages_exists, mock_pdf_image_pages):
         mock_pdfimages_exists.return_value = True
-        mock_pdf_image_pages.return_value = {1}
+        mock_pdf_image_pages.return_value = {1, 2}
         zip_file = "tests/test_data/30-01-2019-RA-eLife-45644.zip"
         zip_file_name = zip_file.split(os.sep)[-1]
         log_prefix = (
@@ -33,10 +33,17 @@ class TestParse(unittest.TestCase):
         ) % zip_file_name
         warning_prefix = ("WARNING %s multiple page PDF figure file:") % log_prefix
         info_prefix = ("INFO %s using pdfimages to check PDF figure file:") % log_prefix
+        info_pages_prefix = (
+            "INFO %s pdfimages found images on pages {1, 2} in PDF figure file:"
+        ) % log_prefix
         expected = [
             "%s 30-01-2019-RA-eLife-45644/Appendix 1figure 10.pdf\n" % info_prefix,
+            "%s 30-01-2019-RA-eLife-45644/Appendix 1figure 10.pdf\n"
+            % info_pages_prefix,
             "%s 30-01-2019-RA-eLife-45644/Appendix 1figure 10.pdf\n" % warning_prefix,
             "%s 30-01-2019-RA-eLife-45644/Appendix 1figure 11.pdf\n" % info_prefix,
+            "%s 30-01-2019-RA-eLife-45644/Appendix 1figure 11.pdf\n"
+            % info_pages_prefix,
             "%s 30-01-2019-RA-eLife-45644/Appendix 1figure 11.pdf\n" % warning_prefix,
         ]
         result = parse.check_ejp_zip(zip_file, self.temp_dir)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6376

Bug fix to https://github.com/elifesciences/elife-cleaner/pull/27

The enhancement resulted in a false positive because the PDF `file_name` was used for the call to `pdfimages` but it should be using the `file_path` of the file on disk.

Also noticed the `finally` statement of the exception handling is not good, because it would be done every time regardless of the number of PDF files.

For easier diagnosis from the log in future, add the page numbers on which `pdfimages` found images in the PDF file.