### PR TITLE
Remove history XML tags for some article types.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7091

Remove the `<history>` tag and its sub elements for particular types of articles when transforming them.