### PR TITLE
Simpler unzip_file(), try for better memory usage.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/zip_lib.py
+++ b/elifecleaner/zip_lib.py
@@ -16,9 +16,8 @@ def profile_zip(file_name):
 
 def unzip_file(open_zipfile, zip_file_info, output_path):
     "read the zip_file_info from the open_zipfile and write to output_path"
-    with open_zipfile.open(zip_file_info) as zip_content:
-        with open(output_path, "wb") as output_file:
-            output_file.write(zip_content.read())
+    with open(output_path, "wb") as output_file:
+        output_file.write(open_zipfile.read(zip_file_info))
 
 
 def unzip_zip(file_name, temp_dir):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7140

A large zip file of about 2 GB when being unzipped encountered a `MemoryError` runtime exception. This is a first try at improving the support for larger files.