### PR TITLE
Refactor parse module to handle unzipped data.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
The `parse.check_ejp_zip()` function required a zip file as its input, which made it difficult to integrate into a workflow that has previously unzipped files in an S3 bucket folder.

The code changes here break apart the processing and checking of data into separate functions, while retaining backwards compatibility of `check_ejp_zip()`.

One backwards compatible change is included in `parse.figure_list()`; it no longer counts the pages of each PDF as part of its routine, the page counting is moved to a new function `parse.set_figure_pdf_pages_count()`. This is also to make it eaiser to integrate with files in an S3 bucket, so the PDF files can be downloaded to the local disk first before the PDF files are opened to count their pages.

The function paths in error messages are different due to the new checking function names.

Tests are refactored for clarity.

A new version of `0.10.0` of the library is chosen for these changes.