### PR TITLE
Add video module for video support.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/utils.py
+++ b/elifecleaner/utils.py
@@ -1,0 +1,3 @@
+def pad_msid(msid):
+    "zerofill string for article_id value"
+    return "{:05d}".format(int(msid))

--- a/elifecleaner/video.py
+++ b/elifecleaner/video.py
@@ -1,0 +1,132 @@
+from collections import OrderedDict
+import re
+from elifecleaner.utils import pad_msid
+
+JOURNAL = "elife"
+
+STRING_TO_TERM_MAP = {
+    "animation": "video",
+    "video": "video",
+    "appendix": "app",
+    "figure": "fig",
+    "video supplement": "video",
+    "videos supplement": "video",
+    "supplementary video": "video",
+}
+
+IGNORE_TERM = "audio"
+
+# todo!!!
+# - raise exception when ignore term is found, or when video term is not found, to distinguish between them
+# - enhance regex to handle mixed numeric values like 6A
+
+
+def video_file_list(files):
+    'get a list of file tags from the XML with @file-type="video"'
+    return [
+        file_data
+        for file_data in files
+        if isinstance(file_data, dict) and file_data.get("file_type") == "video"
+    ]
+
+
+def collect_video_data(files):
+    "from the list of files collect file name and metadata for videos"
+    video_files = video_file_list(files)
+    video_data = []
+    for file_data in video_files:
+        data = OrderedDict()
+        data["upload_file_nm"] = file_data.get("upload_file_nm")
+        for meta in file_data.get("custom_meta"):
+            if meta.get("meta_name") == "Title":
+                data["title"] = meta.get("meta_value")
+                break
+        if len(data.keys()) > 1:
+            video_data.append(data)
+    return video_data
+
+
+def rename_video_data(video_data, article_id):
+    "generate new video filename and id from the video data"
+    generated_video_data = []
+    for data in video_data:
+        video_data_output = OrderedDict()
+        video_data_output["upload_file_nm"] = data.get("upload_file_nm")
+        video_data_output["video_id"] = video_id(data.get("title"))
+        video_data_output["video_filename"] = video_filename(
+            data.get("title"), data.get("upload_file_nm"), article_id
+        )
+        generated_video_data.append(video_data_output)
+    return generated_video_data
+
+
+def video_data_from_files(files, article_id):
+    "from a list of files return video data to be used in renaming files and XML"
+    video_data = collect_video_data(files)
+    return rename_video_data(video_data, article_id)
+
+
+def all_terms(titles):
+    "get a list of all terms for the title values"
+    term_map = OrderedDict()
+    for title in titles:
+        term_map[title] = terms_from_title(title)
+    # todo!! check all title values are non-None
+
+    # check for duplicates
+    a_list = [str(term) for term in term_map.values()]
+    unique_terms = list({str(term) for term in term_map.values()})
+    if len(a_list) != len(unique_terms):
+        # todo!! handle duplicates
+        return None
+    return term_map
+
+
+def terms_from_title(title):
+    "from a title string extract video terms and numbers"
+    terms = []
+    # ignore the value if audio is in the title
+    if IGNORE_TERM in title.lower():
+        return []
+    # convert underscore to space for more lenient matching
+    title = title.replace("_", "")
+    match_pattern = re.compile(r"(\D*?)(\d+)")
+    for match in match_pattern.findall(title):
+        section_term = match[0].lstrip(" -").strip().lower()
+        if section_term in STRING_TO_TERM_MAP:
+            term = OrderedDict()
+            term["name"] = STRING_TO_TERM_MAP.get(section_term)
+            term["number"] = match[1]
+            terms.append(term)
+    # check video is one of the name values
+    if "video" in [term.get("name", "") for term in terms]:
+        return terms
+    return []
+
+
+def video_id(title):
+    "generate an id attribute for a video from its title string"
+    id_string = ""
+    terms = terms_from_title(title)
+    if not terms:
+        return None
+    for term in terms:
+        id_string += "%s%s" % (term.get("name"), term.get("number"))
+    return id_string
+
+
+def video_filename(title, upload_file_nm, article_id, journal=JOURNAL):
+    "generate a new file name for a video file"
+    terms = terms_from_title(title)
+    if not terms:
+        return None
+    new_filename_parts = []
+    new_filename_parts.append(journal)
+    new_filename_parts.append(pad_msid(article_id))
+    for term in terms:
+        new_filename_parts.append("%s%s" % (term.get("name"), term.get("number")))
+    new_filename = "-".join(new_filename_parts)
+    # add file extension
+    file_extension = upload_file_nm.split(".")[-1]
+    new_filename = "%s.%s" % (new_filename, file_extension)
+    return new_filename

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,382 @@
+import unittest
+from collections import OrderedDict
+from elifecleaner import video
+
+
+VIDEO_TITLE_EXAMPLES = [
+    {
+        "comment": "Example of Animation",
+        "article_id": 63107,
+        "title": "Animation 1",
+        "upload_file_nm": "Animation 1.gif",
+        "id": "video1",
+        "filename": "elife-63107-video1.gif",
+    },
+    {
+        "comment": "Example of Appendix",
+        "article_id": 64000,
+        "title": "Appendix 12-figure 1-video 1",
+        "upload_file_nm": "Appendix 12 Figure A1video 1.mov",
+        "id": "app12fig1video1",
+        "filename": "elife-64000-app12-fig1-video1.mov",
+    },
+    {
+        "comment": "Example including Audio will be ignored",
+        "article_id": 62329,
+        "title": "Audio 1",
+        "upload_file_nm": "MaleNarrator_unaltered.mp4",
+        "id": None,
+        "filename": None,
+    },
+    {
+        "comment": "Example of figure animation",
+        "article_id": 56603,
+        "title": "Figure 2-animation 1",
+        "upload_file_nm": "violindecoding_movie.gif",
+        "id": "fig2video1",
+        "filename": "elife-56603-fig2-video1.gif",
+    },
+    {
+        "comment": "Example of video supplement",
+        "article_id": 41328,
+        "title": "Figure 1-video supplement 1",
+        "upload_file_nm": "task low noise.avi",
+        "id": "fig1video1",
+        "filename": "elife-41328-fig1-video1.avi",
+    },
+    {
+        "comment": "Example of videos supplement, plural",
+        "article_id": 52986,
+        "title": "Figure 1-Videos Supplement 1",
+        "upload_file_nm": "Figure 1 Video Supplemental 1A.mp4",
+        "id": "fig1video1",
+        "filename": "elife-52986-fig1-video1.mp4",
+    },
+    {
+        "comment": "Example of Figure Supplement",
+        "article_id": 58962,
+        "title": "Figure 1 - Figure Supplement 3 - video 2",
+        "upload_file_nm": (
+            "Figure 1 Figure supplement 3 video 2. wildtype_microdomain transients in L1 CNS.avi"
+        ),
+        "id": "fig1video2",
+        "filename": "elife-58962-fig1-video2.avi",
+    },
+    {
+        "comment": "Example of Supplementary Video",
+        "article_id": 43542,
+        "title": "Figure 9 - Supplementary Video 1",
+        "upload_file_nm": "supp_figure9_video1.mp4",
+        "id": "fig9video1",
+        "filename": "elife-43542-fig9-video1.mp4",
+    },
+    {
+        "comment": "Example of extra whitespace",
+        "article_id": 51221,
+        "title": "Video  1",
+        "upload_file_nm": "video 1.mp4",
+        "id": "video1",
+        "filename": "elife-51221-video1.mp4",
+    },
+    {
+        "comment": "Example of no whitespace",
+        "article_id": 58145,
+        "title": "Figure2-Video1",
+        "upload_file_nm": "Figure2Movie1.mp4",
+        "id": "fig2video1",
+        "filename": "elife-58145-fig2-video1.mp4",
+    },
+    {
+        "comment": "Example with underscore",
+        "article_id": 62047,
+        "title": "Video_10",
+        "upload_file_nm": "Video_10.mp4",
+        "id": "video10",
+        "filename": "elife-62047-video10.mp4",
+    },
+    {
+        "comment": "Example with underscore and two elements",
+        "article_id": 63755,
+        "title": "Figure 7_video 1",
+        "upload_file_nm": "Figure 7Video 1_Custodio et al_time lapse of colony in Fig.7A.avi",
+        "id": "fig7video1",
+        "filename": "elife-63755-fig7-video1.avi",
+    },
+    {
+        "comment": "Example with a file extension",
+        "article_id": 58626,
+        "title": "Figure 1 Video 1.mp4",
+        "upload_file_nm": "Figure 1_Video 1.mp4",
+        "id": "fig1video1",
+        "filename": "elife-58626-fig1-video1.mp4",
+    },
+    {
+        "comment": "Example of a longer title",
+        "article_id": 40033,
+        "title": "Figure 7-video 2. Murine Fgf2 +/+ hematopoietic progenitors and ....",
+        "upload_file_nm": "mouse DiI KO exosomes  DiO WT BM lin neg.mov",
+        "id": "fig7video2",
+        "filename": "elife-40033-fig7-video2.mov",
+    },
+    {
+        "comment": "Example of missing number",
+        "article_id": 99999,
+        "title": "Figure - Video 1",
+        "upload_file_nm": "video.mp4",
+        "id": None,
+        "filename": None,
+    },
+    {
+        "comment": "Example of a non-numeric figure number",
+        "article_id": 65234,
+        "title": "Figure 6A-video 1",
+        "upload_file_nm": "Figure 6A Video 1.mp4",
+        "id": None,
+        "filename": None,
+    },
+    {
+        "comment": "Example of missing video term",
+        "article_id": 42823,
+        "title": "Figure 3-figure supplement 2",
+        "upload_file_nm": (
+            "Figure 3figure supplement 2. "
+            "Six Chromosome FISH of a C. elegans intestinal nucleus.mp4"
+        ),
+        "id": None,
+        "filename": None,
+    },
+    {
+        "comment": "Example of video typo",
+        "article_id": 47346,
+        "title": "Vidoe 5",
+        "upload_file_nm": "Video 5.mp4",
+        "id": None,
+        "filename": None,
+    },
+    {
+        "comment": "Example of irregular title value",
+        "article_id": 53777,
+        "title": "Potential Striking Image- Live and dynamic IP",
+        "upload_file_nm": "INP_DNeDMS_004 copy.mp4",
+        "id": None,
+        "filename": None,
+    },
+]
+
+VIDEO_FILES_EXAMPLE = [
+    OrderedDict(
+        [
+            ("file_type", "video"),
+            ("upload_file_nm", "Video 1 AVI.avi"),
+            (
+                "custom_meta",
+                [
+                    OrderedDict(
+                        [
+                            ("meta_name", "Title"),
+                            ("meta_value", "Video 1"),
+                        ]
+                    )
+                ],
+            ),
+        ]
+    ),
+    OrderedDict(
+        [
+            ("file_type", "video"),
+            ("upload_file_nm", "Video 2 AVI.avi"),
+            (
+                "custom_meta",
+                [
+                    OrderedDict(
+                        [
+                            ("meta_name", "Title"),
+                            ("meta_value", "Audio 1"),
+                        ]
+                    )
+                ],
+            ),
+        ]
+    ),
+    OrderedDict(
+        [
+            ("file_type", "figure"),
+            ("upload_file_nm", "eLife64719_figure1_classB.png"),
+            (
+                "custom_meta",
+                [
+                    OrderedDict(
+                        [
+                            ("meta_name", "Figure number"),
+                            ("meta_value", "Figure 1"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("meta_name", "Title"),
+                            ("meta_value", "Figure 1"),
+                        ]
+                    ),
+                ],
+            ),
+        ]
+    ),
+]
+
+
+class TestVideoFileList(unittest.TestCase):
+    def test_video_file_list(self):
+        files = VIDEO_FILES_EXAMPLE
+        expected = VIDEO_FILES_EXAMPLE[0:2]
+        self.assertEqual(video.video_file_list(files), expected)
+
+
+class TestCollectVideoData(unittest.TestCase):
+    def test_collect_video_data(self):
+        files = VIDEO_FILES_EXAMPLE
+        expected = [
+            OrderedDict([("upload_file_nm", "Video 1 AVI.avi"), ("title", "Video 1")]),
+            OrderedDict([("upload_file_nm", "Video 2 AVI.avi"), ("title", "Audio 1")]),
+        ]
+        self.assertEqual(video.collect_video_data(files), expected)
+
+
+class TestRenameVideoData(unittest.TestCase):
+    def test_rename_video_data(self):
+        article_id = "3"
+        video_data = [{"upload_file_nm": "Video 1.ogv", "title": "Figure 1 - Video 1"}]
+        expected = [
+            OrderedDict(
+                [
+                    ("upload_file_nm", "Video 1.ogv"),
+                    ("video_id", "fig1video1"),
+                    ("video_filename", "elife-00003-fig1-video1.ogv"),
+                ]
+            )
+        ]
+        self.assertEqual(video.rename_video_data(video_data, article_id), expected)
+
+
+class TestVideoDataFromFiles(unittest.TestCase):
+    def test_video_data_from_files(self):
+        article_id = "3"
+        files = VIDEO_FILES_EXAMPLE
+        expected = [
+            OrderedDict(
+                [
+                    ("upload_file_nm", "Video 1 AVI.avi"),
+                    ("video_id", "video1"),
+                    ("video_filename", "elife-00003-video1.avi"),
+                ]
+            ),
+            OrderedDict(
+                [
+                    ("upload_file_nm", "Video 2 AVI.avi"),
+                    ("video_id", None),
+                    ("video_filename", None),
+                ]
+            ),
+        ]
+        self.assertEqual(video.video_data_from_files(files, article_id), expected)
+
+    def test_video_data_from_files_empty(self):
+        files = [""]
+        article_id = "3"
+        expected = []
+        self.assertEqual(video.video_data_from_files(files, article_id), expected)
+
+
+class TestAllTerms(unittest.TestCase):
+    def test_all_terms(self):
+        titles = ["Figure 1 - Video 1", "Figure 1 - Video 2", "Appendix 2 Video 1"]
+        expected = OrderedDict(
+            [
+                (
+                    "Figure 1 - Video 1",
+                    [
+                        OrderedDict([("name", "fig"), ("number", "1")]),
+                        OrderedDict([("name", "video"), ("number", "1")]),
+                    ],
+                ),
+                (
+                    "Figure 1 - Video 2",
+                    [
+                        OrderedDict([("name", "fig"), ("number", "1")]),
+                        OrderedDict([("name", "video"), ("number", "2")]),
+                    ],
+                ),
+                (
+                    "Appendix 2 Video 1",
+                    [
+                        OrderedDict([("name", "app"), ("number", "2")]),
+                        OrderedDict([("name", "video"), ("number", "1")]),
+                    ],
+                ),
+            ]
+        )
+        all_terms = video.all_terms(titles)
+        self.assertEqual(all_terms, expected, "got all_terms: %s" % all_terms)
+
+    def test_all_terms_duplicate(self):
+        "check return value when there is a duplicate video file name"
+        titles = [
+            "Figure 1 - Video 2",
+            "Figure 1 - Supplementary Video 2",
+            "Figure 1 - Video 1",
+        ]
+        expected = None
+        all_terms = video.all_terms(titles)
+        self.assertEqual(all_terms, expected, "got all_terms: %s" % all_terms)
+
+
+class TestTermsFromTitle(unittest.TestCase):
+    def test_terms_from_title(self):
+        title = (
+            "Animation 999 "
+            "- Video 2 "
+            "- Appendix 3 "
+            "- Figure 4 "
+            "- Figure Supplement 5 "
+            "- Video Supplement 6 "
+            "- Videos Supplement 7 "
+            "- Supplementary Video 8 "
+            "- Vidoe 9"
+        )
+        expected = [
+            OrderedDict([("name", "video"), ("number", "999")]),
+            OrderedDict([("name", "video"), ("number", "2")]),
+            OrderedDict([("name", "app"), ("number", "3")]),
+            OrderedDict([("name", "fig"), ("number", "4")]),
+            OrderedDict([("name", "video"), ("number", "6")]),
+            OrderedDict([("name", "video"), ("number", "7")]),
+            OrderedDict([("name", "video"), ("number", "8")]),
+        ]
+
+        self.assertEqual(video.terms_from_title(title), expected)
+
+    def test_terms_from_title_empty_string(self):
+        title = ""
+        expected = []
+        self.assertEqual(video.terms_from_title(title), expected)
+
+
+class TestVideoId(unittest.TestCase):
+    def test_video_id(self):
+        for test_data in VIDEO_TITLE_EXAMPLES:
+            self.assertEqual(
+                video.video_id(test_data.get("title")), test_data.get("id")
+            )
+
+
+class TestVideoFilename(unittest.TestCase):
+    def test_video_filename(self):
+        for test_data in VIDEO_TITLE_EXAMPLES:
+            self.assertEqual(
+                video.video_filename(
+                    test_data.get("title"),
+                    test_data.get("upload_file_nm"),
+                    test_data.get("article_id"),
+                ),
+                test_data.get("filename"),
+                "title: %s" % test_data.get("title"),
+            )


### PR DESCRIPTION
A new module `elifecleaner/video.py` has been incrementally built up with functionality. It will be used in the `elife-bot` project. Testing it there has confirmed the function calls are proving to be suitable there.

Some todo tasks remain which are not expected to be needed at this time. There may also be some code adjustments later as `elife-bot` development continues and needs this library to be enhanced further.

A new version of `0.12.0` is assigned to the new module addition.