### PR TITLE
Generate video deposit XML and parse XML values.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -296,6 +296,37 @@ def repair_article_xml(xml_string):
     return xml_string
 
 
+def xml_journal_id_values(root):
+    "parse journal-id tags from the XML ElementTree"
+    values = {}
+    for journal_id_tag in root.findall("./front/journal-meta/journal-id"):
+        if journal_id_tag.attrib.get("journal-id-type"):
+            values[journal_id_tag.attrib.get("journal-id-type")] = journal_id_tag.text
+    return values
+
+
+def xml_journal_title(root):
+    "parse the journal title from the XML ElementTree"
+    title = None
+    for journal_title_tag in root.findall(
+        "./front/journal-meta/journal-title-group/journal-title"
+    ):
+        title = journal_title_tag.text
+        break
+    return title
+
+
+def xml_publisher_name(root):
+    "parse the publisher name from the XML ElementTree"
+    name = None
+    for publisher_name_tag in root.findall(
+        "./front/journal-meta/publisher/publisher-name"
+    ):
+        name = publisher_name_tag.text
+        break
+    return name
+
+
 def file_list(root):
     file_list = []
     attribute_map = {

--- a/elifecleaner/video_xml.py
+++ b/elifecleaner/video_xml.py
@@ -1,0 +1,156 @@
+import time
+from xml.dom import minidom
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, SubElement
+from elifearticle import parse as articleparse
+from elifearticle.article import ArticleDate
+from elifecleaner import parse
+from elifecleaner.utils import pad_msid
+
+JOURNAL_ID_TYPES = ["nlm-ta", "publisher-id"]
+
+NAMESPACE_MAP = {
+    "xmlns:mml": "http://www.w3.org/1998/Math/MathML",
+    "xmlns:xlink": "http://www.w3.org/1999/xlink",
+}
+
+MEDIA_CONTENT_TYPE = "glencoe play-in-place height-250 width-310"
+
+DTD_VERSION = "1.1d1"
+
+
+def article_from_xml(xml_file_path):
+    return articleparse.build_article_from_xml(xml_file_path)
+
+
+def set_pub_date(parent, article, pub_type):
+    "set XML pub-date tag to values from an article date"
+    pub_date = article.get_date(pub_type)
+    if pub_date:
+        date_tag = SubElement(parent, "pub-date")
+        date_tag.set("date-type", pub_type)
+        if pub_date.publication_format:
+            date_tag.set("publication-format", pub_date.publication_format)
+        day = SubElement(date_tag, "day")
+        day.text = str(pub_date.date.tm_mday).zfill(2)
+        month = SubElement(date_tag, "month")
+        month.text = str(pub_date.date.tm_mon).zfill(2)
+        year = SubElement(date_tag, "year")
+        year.text = str(pub_date.date.tm_year)
+
+
+def set_article_meta(parent, article):
+    "set XML article-meta tag and tags found inside it"
+    article_meta = SubElement(parent, "article-meta")
+
+    # article-id pub-id-type="publisher-id"
+    if article.manuscript:
+        pub_id_type = "publisher-id"
+        article_id = SubElement(article_meta, "article-id")
+        article_id.text = pad_msid(article.manuscript)
+        article_id.set("pub-id-type", pub_id_type)
+
+    # article-id pub-id-type="doi"
+    if article.doi:
+        pub_id_type = "doi"
+        article_id = SubElement(article_meta, "article-id")
+        article_id.text = article.doi
+        article_id.set("pub-id-type", pub_id_type)
+
+    set_pub_date(article_meta, article, "publication")
+
+
+def set_front(parent, journal_data, article):
+    "set XML front tag and the tags found inside it"
+    front_tag = SubElement(parent, "front")
+    journal_meta = SubElement(front_tag, "journal-meta")
+
+    # journal-id
+    if journal_data.get("journal_ids"):
+        for journal_id_type, value in journal_data.get("journal_ids").items():
+            # concatenate the config name to look for the value
+            if journal_id_type:
+                journal_id = SubElement(journal_meta, "journal-id")
+                journal_id.set("journal-id-type", journal_id_type)
+                journal_id.text = value
+    # journal-title-group
+    journal_title_group = SubElement(journal_meta, "journal-title-group")
+
+    # journal-title
+    if journal_data.get("journal_title"):
+        journal_title_tag = SubElement(journal_title_group, "journal-title")
+        journal_title_tag.text = journal_data.get("journal_title")
+
+    # publisher
+    if journal_data.get("publisher_name"):
+        publisher = SubElement(journal_meta, "publisher")
+        publisher_name_tag = SubElement(publisher, "publisher-name")
+        publisher_name_tag.text = journal_data.get("publisher_name")
+
+    set_article_meta(front_tag, article)
+
+
+def set_body(parent, video_data):
+    "set XML body tag contents"
+    body_tag = SubElement(parent, "body")
+    # video media tags
+    for video in video_data:
+        media_tag = SubElement(body_tag, "media")
+        media_tag.set("xlink:href", video.get("video_filename"))
+        media_tag.set("id", video.get("video_id"))
+        media_tag.set("content-type", MEDIA_CONTENT_TYPE)
+        media_tag.set("mimetype", "video")
+
+
+def output_xml(root, pretty=False, indent=""):
+    "output root XML Element to a string"
+    encoding = "utf-8"
+    rough_string = ElementTree.tostring(root, encoding)
+    reparsed = minidom.parseString(rough_string)
+
+    if pretty is True:
+        return reparsed.toprettyxml(indent, encoding=encoding)
+    return reparsed.toxml(encoding=encoding)
+
+
+def generate_xml(article, journal_data, video_data, pretty=True, indent=""):
+    "from jats_content generate final JATS output"
+
+    # set the date to today
+    article_date = ArticleDate("publication", time.gmtime())
+    article_date.publication_format = "electronic"
+    article.add_date(article_date)
+
+    # Create the root XML node
+    root = Element("article")
+    # set attributes
+    root.set("dtd-version", DTD_VERSION)
+    root.set("article-type", article.article_type)
+    # set namespaces
+    for prefix, url in NAMESPACE_MAP.items():
+        root.set(prefix, url)
+
+    set_front(root, journal_data, article)
+    set_body(root, video_data)
+
+    return output_xml(root, pretty, indent)
+
+
+def glencoe_xml(xml_file_path, video_data, pretty=True, indent=""):
+    "generate XML to be submitted to Glencoe"
+    # build an Article object from the XML
+    article, error_count = article_from_xml(xml_file_path)
+    # collect journal data from the XML elementtree
+    root = parse.parse_article_xml(xml_file_path)
+    journal_ids = parse.xml_journal_id_values(root)
+    filtered_journal_ids = {
+        key: value for key, value in journal_ids.items() if key in JOURNAL_ID_TYPES
+    }
+    journal_title = parse.xml_journal_title(root)
+    publisher_name = parse.xml_publisher_name(root)
+    journal_data = {
+        "journal_ids": filtered_journal_ids,
+        "journal_title": journal_title,
+        "publisher_name": publisher_name,
+    }
+    return generate_xml(article, journal_data, video_data, pretty, indent)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 elifetools==0.12.0
+elifearticle==0.7.0
 mock==4.0.3
 pytest==6.2.2
 Wand==0.6.6

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=["elifecleaner"],
     license="MIT",
-    install_requires=["elifetools", "wand >= 0.5.2"],
+    install_requires=["elifetools", "elifearticle", "wand >= 0.5.2"],
     url="https://github.com/elifesciences/elife-cleaner",
     maintainer="eLife Sciences Publications Ltd.",
     maintainer_email="tech-team@elifesciences.org",

--- a/tests/fixtures/video_xml_64719.xml
+++ b/tests/fixtures/video_xml_64719.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article article-type="research-article" dtd-version="1.1d1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+<front>
+<journal-meta>
+<journal-id journal-id-type="nlm-ta">elife</journal-id>
+<journal-id journal-id-type="publisher-id">eLife</journal-id>
+<journal-title-group>
+<journal-title>eLife</journal-title>
+</journal-title-group>
+<publisher>
+<publisher-name>eLife Sciences Publications, Ltd</publisher-name>
+</publisher>
+</journal-meta>
+<article-meta>
+<article-id pub-id-type="publisher-id">64719</article-id>
+<article-id pub-id-type="doi">10.7554/eLife.64719</article-id>
+<pub-date date-type="publication" publication-format="electronic">
+<day>19</day>
+<month>04</month>
+<year>2022</year>
+</pub-date>
+</article-meta>
+</front>
+<body>
+<media content-type="glencoe play-in-place height-250 width-310" id="video1" mimetype="video" xlink:href="elife-64719-video1.avi"/>
+</body>
+</article>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,7 +21,7 @@ def fixture_module_name(folder_names, filename):
     return ".".join(folder_names + [filename.rstrip(".py")])
 
 
-def read_fixture(filename):
+def read_fixture(filename, mode="r"):
     folder_names = ["tests", "fixtures"]
     full_filename = os.path.join(os.sep.join(folder_names), filename)
     if full_filename.endswith(".py"):
@@ -36,5 +36,8 @@ def read_fixture(filename):
         )
         return mod.EXPECTED
     else:
-        with io.open(full_filename, mode="r", encoding="utf-8") as file_fp:
+        kwargs = {"mode": mode}
+        if mode == "r":
+            kwargs["encoding"] = "utf-8"
+        with io.open(full_filename, **kwargs) as file_fp:
             return file_fp.read()

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -283,6 +283,48 @@ class TestParseArticleXML(unittest.TestCase):
             parse.parse_article_xml(xml_file_path)
 
 
+class TestParseXML(unittest.TestCase):
+    def setUp(self):
+        xml_string = """<article>
+<front>
+  <journal-meta>
+    <journal-id journal-id-type="foo">bar</journal-id>
+    <journal-title-group>
+      <journal-title>eLife</journal-title>
+    </journal-title-group>
+    <publisher>
+        <publisher-name>eLife Sciences Publications, Ltd</publisher-name>
+    </publisher>
+  </journal-meta>
+</front>
+</article>"""
+        self.root = ElementTree.fromstring(xml_string)
+
+    def test_xml_journal_id_values(self):
+        id_values = parse.xml_journal_id_values(self.root)
+        self.assertEqual(id_values, {"foo": "bar"})
+
+    def test_xml_journal_id_values_none(self):
+        id_values = parse.xml_journal_id_values(ElementTree.fromstring("<article/>"))
+        self.assertEqual(id_values, {})
+
+    def test_xml_journal_title(self):
+        title = parse.xml_journal_title(self.root)
+        self.assertEqual(title, "eLife")
+
+    def test_xml_journal_title_none(self):
+        title = parse.xml_journal_title(ElementTree.fromstring("<article/>"))
+        self.assertEqual(title, None)
+
+    def test_xml_publisher_name(self):
+        name = parse.xml_publisher_name(self.root)
+        self.assertEqual(name, "eLife Sciences Publications, Ltd")
+
+    def test_xml_publisher_name_none(self):
+        name = parse.xml_publisher_name(ElementTree.fromstring("<article/>"))
+        self.assertEqual(name, None)
+
+
 class TestRepairArticleXml(unittest.TestCase):
     def test_malformed_xml(self):
         xml_string = "malformed xml"

--- a/tests/test_video_xml.py
+++ b/tests/test_video_xml.py
@@ -1,0 +1,168 @@
+import unittest
+import os
+import time
+import zipfile
+from collections import OrderedDict
+from xml.etree import ElementTree
+from mock import patch
+from elifearticle.article import Article, ArticleDate
+from elifecleaner import video_xml
+from tests.helpers import delete_files_in_folder, read_fixture
+
+JOURNAL_DATA = {
+    "journal_ids": {"nlm-ta": "elife", "publisher-id": "eLife"},
+    "journal_title": "eLife",
+    "publisher_name": "eLife Sciences Publications, Ltd",
+}
+
+VIDEO_DATA = [
+    OrderedDict(
+        [
+            ("upload_file_nm", "Video 1 AVI.avi"),
+            ("video_id", "video1"),
+            ("video_filename", "elife-64719-video1.avi"),
+        ]
+    )
+]
+
+
+def build_article(doi=None, manuscript=None):
+    article = Article(doi=doi)
+    article.manuscript = manuscript
+    return article
+
+
+class TestSetPubDate(unittest.TestCase):
+    def test_set_pub_date(self):
+        root = ElementTree.fromstring("<article/>")
+        article = build_article()
+        pub_type = "electronic"
+        date_time = time.strptime("2022-04-19", "%Y-%m-%d")
+        article.add_date(ArticleDate(pub_type, date_time))
+        expected = (
+            b"<article>"
+            b'<pub-date date-type="%s">'
+            b"<day>19</day>"
+            b"<month>04</month>"
+            b"<year>2022</year>"
+            b"</pub-date>"
+            b"</article>" % bytes(pub_type, "utf-8")
+        )
+        video_xml.set_pub_date(root, article, pub_type)
+        xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertEqual(xml_string, expected)
+
+
+class TestSetArticleMeta(unittest.TestCase):
+    def test_set_article_meta(self):
+        root = ElementTree.fromstring("<article/>")
+        article = build_article("10.7554/eLife.64719", 64719)
+        expected = (
+            b"<article>"
+            b"<article-meta>"
+            b'<article-id pub-id-type="publisher-id">64719</article-id>'
+            b'<article-id pub-id-type="doi">10.7554/eLife.64719</article-id>'
+            b"</article-meta>"
+            b"</article>"
+        )
+        video_xml.set_article_meta(root, article)
+        xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertEqual(xml_string, expected)
+
+
+class TestSetFront(unittest.TestCase):
+    def test_set_front(self):
+        root = ElementTree.fromstring("<article/>")
+        article = build_article("10.7554/eLife.64719", 64719)
+        expected = (
+            b"<article>"
+            b"<front>"
+            b"<journal-meta>"
+            b'<journal-id journal-id-type="nlm-ta">elife</journal-id>'
+            b'<journal-id journal-id-type="publisher-id">eLife</journal-id>'
+            b"<journal-title-group>"
+            b"<journal-title>eLife</journal-title>"
+            b"</journal-title-group>"
+            b"<publisher>"
+            b"<publisher-name>eLife Sciences Publications, Ltd</publisher-name>"
+            b"</publisher>"
+            b"</journal-meta>"
+            b"<article-meta>"
+            b'<article-id pub-id-type="publisher-id">64719</article-id>'
+            b'<article-id pub-id-type="doi">10.7554/eLife.64719</article-id>'
+            b"</article-meta>"
+            b"</front>"
+            b"</article>"
+        )
+        video_xml.set_front(root, JOURNAL_DATA, article)
+        xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertEqual(xml_string, expected)
+
+
+class TestBody(unittest.TestCase):
+    def test_set_body(self):
+        root = ElementTree.fromstring("<article/>")
+        expected = (
+            b"<article>"
+            b"<body>"
+            + (
+                b'<media content-type="glencoe play-in-place height-250 width-310" '
+                b'id="video1" mimetype="video" xlink:href="elife-64719-video1.avi" />'
+            )
+            + b"</body>"
+            b"</article>"
+        )
+        video_xml.set_body(root, VIDEO_DATA)
+        xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertEqual(xml_string, expected)
+
+
+class TestOutputXml(unittest.TestCase):
+    def test_output_xml(self):
+        xml_string = "<article/>"
+        root = ElementTree.fromstring(xml_string)
+        expected = b'<?xml version="1.0" encoding="utf-8"?>' + bytes(
+            xml_string, "utf-8"
+        )
+        output = video_xml.output_xml(root)
+        self.assertEqual(output, expected)
+
+    def test_output_xml_pretty(self):
+        xml_string = "<article/>"
+        root = ElementTree.fromstring(xml_string)
+        expected = (
+            b'<?xml version="1.0" encoding="utf-8"?>'
+            + b"\n"
+            + bytes(xml_string, "utf-8")
+            + b"\n"
+        )
+        output = video_xml.output_xml(root, pretty=True)
+        self.assertEqual(output, expected)
+
+
+class TestGenerateXml(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+
+    def tearDown(self):
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    @patch.object(time, "gmtime")
+    def test_glencoe_xml(self, fake_gmtime):
+        fake_gmtime.return_value = time.strptime("2022-04-19", "%Y-%m-%d")
+        zip_file = "tests/test_data/08-11-2020-FA-eLife-64719.zip"
+        xml_file_name = "08-11-2020-FA-eLife-64719/08-11-2020-FA-eLife-64719.xml"
+        xml_file_path = os.path.join(self.temp_dir, xml_file_name)
+        with zipfile.ZipFile(zip_file, "r") as input_zipfile:
+            input_zipfile.extract(xml_file_name, self.temp_dir)
+        xml_string = video_xml.glencoe_xml(xml_file_path, VIDEO_DATA)
+        expected = read_fixture("video_xml_64719.xml", "rb")
+        self.assertEqual(xml_string, expected)
+
+    @patch.object(time, "gmtime")
+    def test_generate_xml(self, fake_gmtime):
+        fake_gmtime.return_value = time.strptime("2022-04-19", "%Y-%m-%d")
+        article = build_article("10.7554/eLife.64719", 64719)
+        xml_string = video_xml.generate_xml(article, JOURNAL_DATA, VIDEO_DATA)
+        expected = read_fixture("video_xml_64719.xml", "rb")
+        self.assertEqual(xml_string, expected)


### PR DESCRIPTION
A new module `video_xml.py` is added to generate a JATS XML snippet containing video data to be deposited to the video transcoding service.

To generate the XML it takes some metadata from the accepted article XML, which is parsed from ElementTree tags.

The journal metadata and publish date is done by populating an `Article` object, from the `elifearticle` library which is now an additional dependency to this project.

The video data is added to the output XML in the `<media>` tags inside the `<body>`.

All other functions are backwards compatible.

A new version release of `0.13.0` is chosen for these enhancements.