### PR TITLE
Update tests to pass in Python 3.8, and pre-3.8

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/fixtures/video_xml_64719.xml
+++ b/tests/fixtures/video_xml_64719.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article article-type="research-article" dtd-version="1.1d1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1d1" article-type="research-article">
 <front>
 <journal-meta>
 <journal-id journal-id-type="nlm-ta">elife</journal-id>
@@ -22,6 +22,6 @@
 </article-meta>
 </front>
 <body>
-<media content-type="glencoe play-in-place height-250 width-310" id="video1" mimetype="video" xlink:href="elife-64719-video1.avi"/>
+<media xlink:href="elife-64719-video1.avi" id="video1" content-type="glencoe play-in-place height-250 width-310" mimetype="video"/>
 </body>
 </article>

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,6 @@
 import io
 import os
+import sys
 import unittest
 import zipfile
 from xml.etree import ElementTree
@@ -223,14 +224,23 @@ class TestTransform(unittest.TestCase):
 
 class TestXmlElementToString(unittest.TestCase):
     def test_xml_element_to_string(self):
+        if sys.version_info < (3, 8):
+            # pre Python 3.8 tag attributes are automatically alphabetised
+            article_tag_xml_string = (
+                '<article article-type="research-article"'
+                ' xmlns:xlink="http://www.w3.org/1999/xlink">'
+            )
+        else:
+            article_tag_xml_string = (
+                '<article xmlns:xlink="http://www.w3.org/1999/xlink"'
+                ' article-type="research-article">'
+            )
         xml_string = (
-            '<article article-type="research-article"'
-            ' xmlns:xlink="http://www.w3.org/1999/xlink">'
-            "<front><article-meta><permissions>"
+            "%s<front><article-meta><permissions>"
             '<license license-type="open-access"'
             ' xlink:href="http://creativecommons.org/licenses/by/4.0/"/>'
             "</permissions></article-meta></front>"
-            "</article>"
+            "</article>" % article_tag_xml_string
         )
         root = ElementTree.fromstring(xml_string)
         expected = '<?xml version="1.0" ?>%s' % xml_string


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7490

Since Python 3.8, XML tag attribute order is preserved instead of automatically alphabetised, when using `ElementTree`. Here, one test fixture is updated to reflect the output when using Python 3.8, and other tests are modified to test for Python 3.8 output and pre-Python-3.8 output, depending on which version is used when running tests.

A new version of `0.14.0` is assigned to recognise the difference in XML output.