### PR TITLE
Add to funding-statement if Wellcome is a funder.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7293

If any funding source includes the term "wellcome" (by case insensitive matching), add a sentence to the `<funding-statement>` tag. Do not add the sentence if it is already there. If there's no `<funding-statement>` tag, then add the tag and then add the sentence to it.

It is invoked as part of the `transform_xml()` function.

Suggesting a new library version of `0.15.0` for this.