### PR TITLE
Improved video title matching and figure name matching 

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -155,7 +155,7 @@ def find_missing_files_by_name(files):
         {
             "file_types": ["figure"],
             "meta_names": ["Title", "Figure number"],
-            "match_pattern": r"Figure (\d+)",
+            "match_pattern": r"Figure\s+(\d+)",
         }
     ]
     for match_rule in match_rules:
@@ -222,8 +222,10 @@ def find_missing_value_by_sequence(values, match_pattern):
         if prev_number:
             expected_number = prev_number + 1
         if expected_number and number > expected_number:
+            # remove whitespace match pattern
+            label_pattern = match_pattern.replace(r"\s+", " ")
             # replace (\d) from the match pattern to get a missing file name
-            label = label_match.sub(str(expected_number), match_pattern)
+            label = label_match.sub(str(expected_number), label_pattern)
             missing_files.append(label)
         prev_number = number
 

--- a/elifecleaner/video.py
+++ b/elifecleaner/video.py
@@ -88,8 +88,9 @@ def terms_from_title(title):
     # ignore the value if audio is in the title
     if IGNORE_TERM in title.lower():
         return []
-    # convert underscore to space for more lenient matching
-    title = title.replace("_", "")
+    # convert some punctuation to space for more lenient matching
+    for char in ["_", "-"]:
+        title = title.replace(char, " ")
     match_pattern = re.compile(r"(\D*?)(\d+)")
     for match in match_pattern.findall(title):
         section_term = match[0].lstrip(" -").strip().lower()

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -635,6 +635,12 @@ class TestFindMissingFilesByName(unittest.TestCase):
         expected = ["Figure 2"]
         self.assertEqual(parse.find_missing_files_by_name(self.files), expected)
 
+    def test_find_missing_files_by_name_extra_whitespace(self):
+        "test pattern matching if there is whitespace"
+        self.files[1]["custom_meta"][0]["meta_value"] = "Figure  \t     3"
+        expected = ["Figure 2"]
+        self.assertEqual(parse.find_missing_files_by_name(self.files), expected)
+
     def test_find_file_detail_values_empty(self):
         files = []
         file_types = []

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -340,6 +340,7 @@ class TestTermsFromTitle(unittest.TestCase):
             "- Video Supplement 6 "
             "- Videos Supplement 7 "
             "- Supplementary Video 8 "
+            "Figure-4-Video 2"
             "- Vidoe 9"
         )
         expected = [
@@ -350,6 +351,8 @@ class TestTermsFromTitle(unittest.TestCase):
             OrderedDict([("name", "video"), ("number", "6")]),
             OrderedDict([("name", "video"), ("number", "7")]),
             OrderedDict([("name", "video"), ("number", "8")]),
+            OrderedDict([("name", "fig"), ("number", "4")]),
+            OrderedDict([("name", "video"), ("number", "2")]),
         ]
 
         self.assertEqual(video.terms_from_title(title), expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7530, where a video title used `-` hyphen characters.

Also today an example where a figure title and its number was separated by more than one space character.

Tests are included for these more variable input values.

A new version of this library `0.16.0` is assigned.