### PR TITLE
Replace control character entities in XML string.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 import html
 from wand.image import Image
 from wand.exceptions import PolicyError, WandRuntimeError
-from elifecleaner import LOGGER, pdf_utils, zip_lib
+from elifecleaner import LOGGER, pdf_utils, utils, zip_lib
 
 
 # flag for whether to try and repair XML if it encounters a ParseError
@@ -281,6 +281,13 @@ def parse_article_xml(xml_file):
         xml_string = open_file.read()
         # unescape any HTML entities to avoid undefined entity XML exceptions later
         xml_string = html_entity_unescape(xml_string)
+        # fix XML-incompatible character entities
+        if utils.match_control_character_entities(xml_string):
+            LOGGER.info(
+                "Replacing character entities in the XML string: %s"
+                % utils.match_control_character_entities(xml_string)
+            )
+            xml_string = utils.replace_control_character_entities(xml_string)
         try:
             return ElementTree.fromstring(xml_string)
         except ElementTree.ParseError:

--- a/elifecleaner/utils.py
+++ b/elifecleaner/utils.py
@@ -1,3 +1,25 @@
+import re
+
+
 def pad_msid(msid):
     "zerofill string for article_id value"
     return "{:05d}".format(int(msid))
+
+
+# match ascii characters from decimal 0 to 31, as hexidecimal character entitiy strings
+# e.g. &#x001D; or &#x01;
+CONTROL_CHARACTER_ENTITY_MATCH_PATTERN = r"&#x0{0,2}[0-1][0-9A-Fa-f];"
+# string to replace character entities with
+CONTROL_CHARACTER_ENTITY_REPLACEMENT = "_____"
+
+
+def match_control_character_entities(string):
+    "search the string for character entities of XML-incompatible control characters"
+    match_pattern = re.compile(CONTROL_CHARACTER_ENTITY_MATCH_PATTERN)
+    return match_pattern.findall(string)
+
+
+def replace_control_character_entities(string):
+    "replace character entities of control characters in the string"
+    match_pattern = re.compile(CONTROL_CHARACTER_ENTITY_MATCH_PATTERN)
+    return match_pattern.sub(CONTROL_CHARACTER_ENTITY_REPLACEMENT, string)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,44 @@
+import unittest
+from elifecleaner import utils
+
+
+class TestPadMsid(unittest.TestCase):
+    def test_pad_msid(self):
+        self.assertEqual(utils.pad_msid(666), "00666")
+        self.assertEqual(utils.pad_msid("666"), "00666")
+
+
+class TestMatchControlCharacterEntities(unittest.TestCase):
+    def test_match_control_character_entities(self):
+        self.assertEqual([], utils.match_control_character_entities(""))
+        self.assertEqual(
+            ["&#x001C;"], utils.match_control_character_entities("&#x001C;")
+        )
+        self.assertEqual(
+            ["&#x001C;"], utils.match_control_character_entities("aaaa&#x001C;--")
+        )
+        self.assertEqual(
+            ["&#x001E;", "&#x001E;"],
+            utils.match_control_character_entities(" &#x001E;--&#x001E;"),
+        )
+
+
+class TestReplaceControlCharacterEntities(unittest.TestCase):
+    def test_replace_control_character_entities(self):
+        # empty string
+        self.assertEqual("", utils.replace_control_character_entities(""))
+        # one entity
+        self.assertEqual(
+            utils.CONTROL_CHARACTER_ENTITY_REPLACEMENT,
+            utils.replace_control_character_entities("&#x001C;"),
+        )
+        # multiple entities
+        self.assertEqual(
+            utils.CONTROL_CHARACTER_ENTITY_REPLACEMENT * 4,
+            utils.replace_control_character_entities("&#x00;&#x001C;&#x001D;&#x001E;"),
+        )
+        # entity found inside a string
+        string_base = "<title>To %snd odd entities.</title>"
+        string = string_base % "&#x001D;"
+        expected = string_base % utils.CONTROL_CHARACTER_ENTITY_REPLACEMENT
+        self.assertEqual(expected, utils.replace_control_character_entities(string))


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7577

Character entities for ASCII code 0 to 31 are control characters, and if hex format character entities for these are in the XML string then the ElementTree parser fails to parse it as XML. These functions are changed to replace the weird character entities with five underscores `_____` (configurable in a constant in the `utils.py` module) so they are easier to spot in proofing software.