### PR TITLE
sub_article.py to generate sub-article XML tag.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -1,0 +1,94 @@
+from xml.etree.ElementTree import Element, SubElement
+from jatsgenerator import build
+
+XML_NAMESPACES = {
+    "ali": "http://www.niso.org/schemas/ali/1.0/",
+    "mml": "http://www.w3.org/1998/Math/MathML",
+    "xlink": "http://www.w3.org/1999/xlink",
+}
+
+
+def generate(sub_article_data, root_tag="article"):
+    "generate a sub-article XML tag for each article"
+    root = Element(root_tag)
+
+    for data in sub_article_data:
+        article = data.get("article")
+        sub_article_root = data.get("xml_root")
+
+        # set the article-type for each article
+        sub_article_tag = sub_article(root, article.id, article.article_type)
+
+        # front-stub parent tag
+        front_stub_tag = SubElement(sub_article_tag, "front-stub")
+
+        build.set_article_id(front_stub_tag, article)
+        build.set_title_group(front_stub_tag, article)
+
+        # add contributor tags
+        if article.contributors:
+            set_contrib(front_stub_tag, article)
+
+        build.set_related_object(front_stub_tag, article)
+
+        # set body from the sub-article XML
+        body_tag = sub_article_root.find("body")
+        if body_tag is not None:
+            sub_article_tag.append(body_tag)
+
+    # repair namespaces
+    repair_namespaces(root)
+
+    return root
+
+
+def repair_namespaces(root):
+    "repair XML namespaces by adding namespaces if missing"
+    all_attributes = set()
+    for tag in root.iter("*"):
+        all_attributes = all_attributes.union(
+            all_attributes, {attribute_name for attribute_name in tag.attrib.keys()}
+        )
+    prefix_attributes = {
+        attrib.split(":")[0] for attrib in all_attributes if ":" in attrib
+    }
+
+    for prefix in prefix_attributes:
+        if prefix in XML_NAMESPACES.keys():
+            ns_attrib = "xmlns:%s" % prefix
+            root.set(ns_attrib, XML_NAMESPACES.get(prefix))
+
+
+def sub_article(parent, id_attribute=None, article_type=None):
+    sub_article_tag = SubElement(parent, "sub-article")
+    if id_attribute:
+        sub_article_tag.set("id", id_attribute)
+    if article_type:
+        sub_article_tag.set("article-type", article_type)
+    return sub_article_tag
+
+
+def set_contrib(parent, article, contrib_type=None):
+    contrib_group = SubElement(parent, "contrib-group")
+
+    for contributor in article.contributors:
+        contrib_tag = SubElement(contrib_group, "contrib")
+        contrib_tag.set("contrib-type", contributor.contrib_type)
+        build.set_contrib_name(contrib_tag, contributor)
+
+        # set role tag
+        build.set_contrib_role(contrib_tag, contrib_type, contributor)
+
+        # set orcid tag with authenticated=true tag attribute
+        build.set_contrib_orcid(contrib_tag, contributor)
+
+        # add aff tag(s)
+        for affiliation in contributor.affiliations:
+            build.set_aff(
+                contrib_tag,
+                affiliation,
+                contrib_type,
+                aff_id=None,
+                tail="",
+                institution_wrap=True,
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 elifetools==0.12.0
-elifearticle==0.7.0
+elifearticle==0.11.0
+jatsgenerator==0.5.0
 mock==4.0.3
 pytest==6.2.2
 Wand==0.6.6

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,12 @@ setup(
     long_description_content_type="text/markdown",
     packages=["elifecleaner"],
     license="MIT",
-    install_requires=["elifetools", "elifearticle", "wand >= 0.5.2"],
+    install_requires=[
+        "elifetools",
+        "elifearticle>=0.10.0",
+        "jatsgenerator>=0.4.0",
+        "wand >= 0.5.2",
+    ],
     url="https://github.com/elifesciences/elife-cleaner",
     maintainer="eLife Sciences Publications Ltd.",
     maintainer_email="tech-team@elifesciences.org",

--- a/tests/fixtures/sub_articles.xml
+++ b/tests/fixtures/sub_articles.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <sub-article id="sa0" article-type="editor-report">
+    <front-stub>
+      <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa0</article-id>
+      <title-group>
+        <article-title>eLife assessment</article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Surname</surname>
+            <given-names>Given</given-names>
+            <suffix>X</suffix>
+          </name>
+          <contrib-id authenticated="true" contrib-id-type="orcid">http://orcid.org/https://orcid.org/0000-0000-0000-0000</contrib-id>
+          <aff>
+            <institution-wrap>
+              <institution-id institution-id="ror">ror</institution-id>
+              <institution content-type="dept">Department</institution>
+              <institution>Institution</institution>
+            </institution-wrap>
+            <addr-line>
+              <named-content content-type="city">City</named-content>
+            </addr-line>
+            <country>Country</country>
+            <phone>Phone</phone>
+            <fax>Fax</fax>
+          </aff>
+        </contrib>
+      </contrib-group>
+      <related-object id="sa0ro1" object-id-type="id" object-id="10.1101/2021.11.09.467796" link-type="continued-by" xlink:href="https://sciety.org/articles/activity/10.1101/2021.11.09.467796"/>
+    </front-stub>
+    <body>
+      <p>
+        <bold>Test</bold>
+         
+        <sup>superscript</sup>
+         
+        <sub>subscript</sub>
+         &amp; p&lt;0.001 
+        <italic>C. elegans</italic>
+      </p>
+      <p>
+        <inline-formula>
+          <mml:math display="inline" alttext="n">
+            <mml:mi>n</mml:mi>
+          </mml:math>
+        </inline-formula>
+      </p>
+    </body>
+  </sub-article>
+  <sub-article id="sa2" article-type="referee-report">
+    <front-stub>
+      <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa2</article-id>
+      <title-group>
+        <article-title>Reviewer #1 (public review)</article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <anonymous/>
+          <role specific-use="referee">Reviewer</role>
+        </contrib>
+      </contrib-group>
+    </front-stub>
+    <body>
+      <p>Review.</p>
+    </body>
+  </sub-article>
+  <sub-article id="sa3" article-type="author-comment">
+    <front-stub>
+      <article-id pub-id-type="doi">10.7554/eLife.1234567890.4.sa3</article-id>
+      <title-group>
+        <article-title>Author response</article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Surname</surname>
+            <given-names>Given</given-names>
+            <suffix>X</suffix>
+          </name>
+        </contrib>
+      </contrib-group>
+    </front-stub>
+    <body>
+      <disp-quote content-type="editor-comment">Quotation.</disp-quote>
+      <p>Response.</p>
+    </body>
+  </sub-article>
+</article>

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -1,0 +1,149 @@
+import unittest
+from xml.etree import ElementTree
+from xml.dom import minidom
+from elifearticle.article import (
+    Affiliation,
+    Article,
+    Contributor,
+    RelatedArticle,
+    Role,
+)
+from elifetools import xmlio
+from elifecleaner import sub_article
+from tests.helpers import read_fixture
+
+
+def editor_report_article_fixture(
+    id_attribute="sa0",
+    doi="10.7554/eLife.1234567890.4.sa0",
+):
+    "populate an editor-report Article for testing"
+    article = Article(doi)
+    article.article_type = "editor-report"
+    article.title = "eLife assessment"
+    article.id = id_attribute
+    related_article = RelatedArticle()
+    related_article.ext_link_type = "continued-by"
+    related_article.xlink_href = (
+        "https://sciety.org/articles/activity/10.1101/2021.11.09.467796"
+    )
+    article.related_articles = [related_article]
+    # contributors
+    author = Contributor("author", "Surname", "Given")
+    author.suffix = "X"
+    author.orcid = "https://orcid.org/0000-0000-0000-0000"
+    author.orcid_authenticated = True
+    # aff
+    aff = Affiliation()
+    aff.phone = "Phone"
+    aff.fax = "Fax"
+    aff.department = "Department"
+    aff.institution = "Institution"
+    aff.city = "City"
+    aff.country = "Country"
+    aff.ror = "ror"
+    author.set_affiliation(aff)
+    # add the author to the article
+    article.add_contributor(author)
+    return article
+
+
+def referee_report_article_fixture(
+    id_attribute="sa2",
+    doi="10.7554/eLife.1234567890.4.sa2",
+    title="Reviewer #1 (public review)",
+):
+    "populate a referee-report Article for testing"
+    article = Article(doi)
+    article.article_type = "referee-report"
+    article.title = title
+    article.id = id_attribute
+    # contributors
+    anonymous_author = Contributor("author", None, None)
+    anonymous_author.roles = [Role("Reviewer", "referee")]
+    # setattr(anonymous_author, "anonymous", True)
+    anonymous_author.anonymous = True
+    # add the author to the article
+    article.add_contributor(anonymous_author)
+    return article
+
+
+def author_comment_article_fixture(
+    id_attribute="sa3",
+    doi="10.7554/eLife.1234567890.4.sa3",
+):
+    "populate an author-comment Article for testing"
+    article = Article(doi)
+    article.article_type = "author-comment"
+    article.title = "Author response"
+    article.id = id_attribute
+    # contributors
+    author = Contributor("author", "Surname", "Given")
+    author.suffix = "X"
+    article.add_contributor(author)
+    return article
+
+
+class TestGenerate(unittest.TestCase):
+    def test_generate(self):
+        editor_report_article = editor_report_article_fixture()
+        referee_report_article = referee_report_article_fixture()
+        author_comment_article = author_comment_article_fixture()
+
+        # XML generated from docmap-tools
+        # register XML namespaces
+        xmlio.register_xmlns()
+        editor_report_xml_string = (
+            '<root xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            "<body>"
+            "<p><bold>Test</bold> <sup>superscript</sup> <sub>subscript</sub> &amp; p&lt;0.001 "
+            "<italic>C. elegans</italic></p>"
+            "<p><inline-formula>"
+            '<mml:math display="inline" alttext="n"><mml:mi>n</mml:mi></mml:math>'
+            "</inline-formula></p>"
+            "</body></root>"
+        )
+        editor_report_sub_article_root = ElementTree.fromstring(
+            editor_report_xml_string
+        )
+        referee_report_xml_string = "<root><body><p>Review.</p></body></root>"
+        referee_report_sub_article_root = ElementTree.fromstring(
+            referee_report_xml_string
+        )
+        author_comment_xml_string = (
+            "<root>"
+            "<body>"
+            '<disp-quote content-type="editor-comment">Quotation.</disp-quote>'
+            "<p>Response.</p>"
+            "</body>"
+            "</root>"
+        )
+        author_comment_sub_article_root = ElementTree.fromstring(
+            author_comment_xml_string
+        )
+
+        # assemble sub article data
+        sub_article_1 = {
+            "article": editor_report_article,
+            "xml_root": editor_report_sub_article_root,
+        }
+        sub_article_2 = {
+            "article": referee_report_article,
+            "xml_root": referee_report_sub_article_root,
+        }
+        sub_article_3 = {
+            "article": author_comment_article,
+            "xml_root": author_comment_sub_article_root,
+        }
+        # build XML
+        sub_article_data = [sub_article_1, sub_article_2, sub_article_3]
+        root = sub_article.generate(sub_article_data)
+        expected = read_fixture("sub_articles.xml", mode="rb")
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        # parse the XML string to produce pretty output and
+        # also check for XML namespace parsing errors
+        reparsed = minidom.parseString(rough_xml_string)
+        pretty_xml_string = reparsed.toprettyxml(indent="  ", encoding="utf-8")
+
+        self.assertEqual(pretty_xml_string, expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7569

First step to adding `<sub-article>` XML to the article XML file, the new module `sub_article.py` uses `Article` object data along with the `<body>` from an Element to generate a `<sub-aritcle>` tag for each.

Some further enhancements and fixes will come later after attempts to integrate it into an operational workflow, and to use the `docmap-tools` library for the `<body>` and other metadata.