### PR TITLE
prc.py module for PRC related functions.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -1,0 +1,79 @@
+from xml.etree.ElementTree import SubElement
+from elifecleaner import LOGGER
+
+# for each ISSN, values for journal-id-type tag text
+ISSN_JOURNAL_ID_MAP = {
+    "2050-084X": {
+        "nlm-ta": "elife",
+        "hwp": "eLife",
+        "publisher-id": "eLife",
+    }
+}
+
+
+def yield_journal_id_tags(root, journal_id_types):
+    "find journal-id tags with matched journal-id-type attribute"
+    for journal_id_tag in root.findall("./front/journal-meta/journal-id"):
+        if (
+            journal_id_tag.get("journal-id-type")
+            and journal_id_tag.get("journal-id-type") in journal_id_types
+        ):
+            yield journal_id_tag
+
+
+def is_xml_prc(root):
+    "check if the XML is PRC format by comparing journal-id tag text for a mismatch"
+    issn_tag = root.find("./front/journal-meta/issn")
+    if issn_tag is None:
+        return False
+    if issn_tag.text in ISSN_JOURNAL_ID_MAP:
+        journal_id_type_map = ISSN_JOURNAL_ID_MAP.get(issn_tag.text)
+        # check if any of the journal-id tag values do not match the expected values
+        for journal_id_tag in yield_journal_id_tags(root, journal_id_type_map.keys()):
+            if journal_id_tag.text != journal_id_type_map.get(
+                journal_id_tag.get("journal-id-type")
+            ):
+                return True
+    return False
+
+
+def transform_journal_id_tags(root, identifier=None):
+    "replace file name tags in xml Element with names from file transformations list"
+    issn_tag = root.find("./front/journal-meta/issn")
+    if issn_tag is not None and issn_tag.text in ISSN_JOURNAL_ID_MAP:
+        journal_id_type_map = ISSN_JOURNAL_ID_MAP.get(issn_tag.text)
+        for journal_id_tag in yield_journal_id_tags(root, journal_id_type_map.keys()):
+            LOGGER.info(
+                "%s replacing journal-id tag text of type %s to %s",
+                identifier,
+                journal_id_tag.get("journal-id-type"),
+                journal_id_type_map.get(journal_id_tag.get("journal-id-type")),
+            )
+
+            journal_id_tag.text = journal_id_type_map.get(
+                journal_id_tag.get("journal-id-type")
+            )
+    return root
+
+
+def add_prc_custom_meta_tags(root, identifier=None):
+    "add custom-meta tag in custom-meta-group"
+    article_meta_tag = root.find(".//front/article-meta")
+    if article_meta_tag is None:
+        LOGGER.warning(
+            "%s article-meta tag not found",
+            identifier,
+        )
+        return root
+    custom_meta_group_tag = article_meta_tag.find("custom-meta-group")
+    if custom_meta_group_tag is None:
+        # add the custom-meta-group tag
+        custom_meta_group_tag = SubElement(article_meta_tag, "custom-meta-group")
+    # add the custom-meta tag
+    custom_meta_tag = SubElement(custom_meta_group_tag, "custom-meta")
+    custom_meta_tag.set("specific-use", "meta-only")
+    meta_name_tag = SubElement(custom_meta_tag, "meta-name")
+    meta_name_tag.text = "publishing-route"
+    meta_value_tag = SubElement(custom_meta_tag, "meta-value")
+    meta_value_tag.text = "prc"
+    return root

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -1,0 +1,163 @@
+import os
+import unittest
+from xml.etree import ElementTree
+from elifecleaner import LOGGER, configure_logging, prc
+from tests.helpers import delete_files_in_folder
+
+# elife ISSN example of non-PRC journal-id tag values
+NON_PRC_XML = (
+    "<article><front><journal-meta>"
+    '<journal-id journal-id-type="nlm-ta">elife</journal-id>'
+    '<journal-id journal-id-type="hwp">eLife</journal-id>'
+    '<journal-id journal-id-type="publisher-id">eLife</journal-id>'
+    "<journal-title-group>"
+    "<journal-title>eLife</journal-title>"
+    "</journal-title-group>"
+    '<issn pub-type="epub">2050-084X</issn>'
+    "<publisher>"
+    "<publisher-name>eLife Sciences Publications, Ltd</publisher-name>"
+    "</publisher>"
+    "</journal-meta></front></article>"
+)
+
+# PRC xml will have non-eLife journal-id tag text values
+PRC_XML = (
+    "<article><front><journal-meta>"
+    '<journal-id journal-id-type="nlm-ta">foo</journal-id>'
+    '<journal-id journal-id-type="hwp">foo</journal-id>'
+    '<journal-id journal-id-type="publisher-id">foo</journal-id>'
+    "<journal-title-group>"
+    "<journal-title>eLife</journal-title>"
+    "</journal-title-group>"
+    '<issn pub-type="epub">2050-084X</issn>'
+    "<publisher>"
+    "<publisher-name>eLife Sciences Publications, Ltd</publisher-name>"
+    "</publisher>"
+    "</journal-meta></front></article>"
+)
+
+
+class TestIsXmlPrc(unittest.TestCase):
+    def test_is_xml_prc(self):
+        "PRC XML will return true"
+        root = ElementTree.fromstring(PRC_XML)
+        self.assertTrue(prc.is_xml_prc(root))
+
+    def test_is_xml_prc_false(self):
+        "test non-PRC XML will return false"
+        root = ElementTree.fromstring(NON_PRC_XML)
+        self.assertEqual(prc.is_xml_prc(root), False)
+
+    def test_is_xml_prc_incomplete(self):
+        "incomplete XML will return false"
+        root = ElementTree.fromstring("<root/>")
+        self.assertEqual(prc.is_xml_prc(root), False)
+
+
+class TestTransformJournalIdTags(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+        self.log_file = os.path.join(self.temp_dir, "test.log")
+        self.log_handler = configure_logging(self.log_file)
+
+    def tearDown(self):
+        LOGGER.removeHandler(self.log_handler)
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_transform_journal_id_tags(self):
+        # populate an ElementTree
+        identifier = "test.zip"
+        xml_string = PRC_XML
+        expected = bytes(NON_PRC_XML, encoding="utf-8")
+        root = ElementTree.fromstring(xml_string)
+        # invoke the function
+        root_output = prc.transform_journal_id_tags(root, identifier)
+        # assertions
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+        log_file_lines = []
+        with open(self.log_file, "r") as open_file:
+            for line in open_file:
+                log_file_lines.append(line)
+        for index, (journal_id_type, tag_text) in enumerate(
+            [("nlm-ta", "elife"), ("hwp", "eLife"), ("publisher-id", "eLife")]
+        ):
+            self.assertEqual(
+                log_file_lines[index],
+                (
+                    (
+                        "INFO elifecleaner:prc:transform_journal_id_tags: "
+                        "%s replacing journal-id tag text of type %s to %s\n"
+                    )
+                )
+                % (identifier, journal_id_type, tag_text),
+            )
+
+
+class TestAddPrcCustomMetaTags(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = "tests/tmp"
+        self.log_file = os.path.join(self.temp_dir, "test.log")
+        self.log_handler = configure_logging(self.log_file)
+        self.expected_xml = bytes(
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            "<custom-meta-group>"
+            '<custom-meta specific-use="meta-only">'
+            "<meta-name>publishing-route</meta-name>"
+            "<meta-value>prc</meta-value>"
+            "</custom-meta>"
+            "</custom-meta-group>"
+            "</article-meta>"
+            "</front>"
+            "</article>",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        LOGGER.removeHandler(self.log_handler)
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_add_custom_meta_tags(self):
+        "test when custom-meta-group tag does not yet exist"
+        # populate an ElementTree
+        xml_string = "<article><front><article-meta/></front></article>"
+        root = ElementTree.fromstring(xml_string)
+        # invoke the function
+        root_output = prc.add_prc_custom_meta_tags(root)
+        # assertions
+        self.assertEqual(ElementTree.tostring(root_output), self.expected_xml)
+
+    def test_group_tag_exists(self):
+        "test if custom-meta-group tag already exists"
+        # populate an ElementTree
+        xml_string = (
+            "<article><front><article-meta>"
+            "<custom-meta-group />"
+            "</article-meta></front></article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        # invoke the function
+        root_output = prc.add_prc_custom_meta_tags(root)
+        # assertions
+        self.assertEqual(ElementTree.tostring(root_output), self.expected_xml)
+
+    def test_no_article_meta_tag(self):
+        # populate an ElementTree
+        identifier = "test.zip"
+        xml_string = "<root/>"
+        expected = b"<root />"
+        root = ElementTree.fromstring(xml_string)
+        # invoke the function
+        root_output = prc.add_prc_custom_meta_tags(root, identifier)
+        # assertions
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+        with open(self.log_file, "r") as open_file:
+            self.assertEqual(
+                open_file.read(),
+                (
+                    "WARNING elifecleaner:prc:add_prc_custom_meta_tags: "
+                    "%s article-meta tag not found\n"
+                )
+                % identifier,
+            )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7880

For PRC (Publish Review Curate) style XML, a module for detecting values in eLife XML files and to modify XML tagging.