### PR TITLE
Replace control characters before parsing XML.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -288,6 +288,13 @@ def parse_article_xml(xml_file):
                 % utils.match_control_character_entities(xml_string)
             )
             xml_string = utils.replace_control_character_entities(xml_string)
+        # also replace unescaped control characters
+        if utils.match_control_characters(xml_string):
+            LOGGER.info(
+                "Replacing control characters in the XML string (ASCII codes): %s"
+                % [ord(char) for char in utils.match_control_characters(xml_string)]
+            )
+            xml_string = utils.replace_control_characters(xml_string)
         try:
             return ElementTree.fromstring(xml_string)
         except ElementTree.ParseError:

--- a/elifecleaner/utils.py
+++ b/elifecleaner/utils.py
@@ -23,3 +23,17 @@ def replace_control_character_entities(string):
     "replace character entities of control characters in the string"
     match_pattern = re.compile(CONTROL_CHARACTER_ENTITY_MATCH_PATTERN)
     return match_pattern.sub(CONTROL_CHARACTER_ENTITY_REPLACEMENT, string)
+
+
+def match_control_characters(string):
+    "search the string for XML-incompatible control characters"
+    # char 9 is newline, 10 is tab, 13 is carriage return
+    allowed = [9, 10, 13]
+    return [char for char in string[:] if ord(char) <= 31 and ord(char) not in allowed]
+
+
+def replace_control_characters(string):
+    "replace control characters in the string"
+    for char in list(set(match_control_characters(string))):
+        string = string.replace(char, CONTROL_CHARACTER_ENTITY_REPLACEMENT)
+    return string

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -290,6 +290,19 @@ class TestParseArticleXML(unittest.TestCase):
         self.assertIsNotNone(root)
         self.assertEqual(ElementTree.tostring(root), expected)
 
+    def test_parse_article_xml_control_characters(self):
+        xml_file_path = os.path.join(self.temp_dir, "test.xml")
+        with open(xml_file_path, "w") as open_file:
+            open_file.write(
+                "<article><title>To %snd odd entities.</title></article>" % chr(29)
+            )
+        expected = b"<article><title>To %snd odd entities.</title></article>" % bytes(
+            CONTROL_CHARACTER_ENTITY_REPLACEMENT, encoding="utf-8"
+        )
+        root = parse.parse_article_xml(xml_file_path)
+        self.assertIsNotNone(root)
+        self.assertEqual(ElementTree.tostring(root), expected)
+
     def test_parse_article_xml_failure(self):
         xml_file_path = os.path.join(self.temp_dir, "test.xml")
         with open(xml_file_path, "w") as open_file:


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7927

Some XML files contain control characters which cause XML parser errors, in particular ascii char 29. Unwanted control characters will be replaced in the XML string prior to parsing it into an XML `ElementTree`.