### PR TITLE
Set sub-article id attribute when building object.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -86,9 +86,14 @@ def sub_article_data(docmap_string, article):
     return format_content_json(content_json, article)
 
 
+def sub_article_id(index):
+    "generate an id attribute for a sub article"
+    return "sa%s" % index
+
+
 def sub_article_doi(article_doi, index):
     "generate a DOI for a sub article"
-    return "%s.sa%s" % (article_doi, index)
+    return "%s.%s" % (article_doi, sub_article_id(index))
 
 
 def sub_article_contributors(article_object, sub_article_object):
@@ -117,6 +122,8 @@ def sub_article_contributors(article_object, sub_article_object):
 def build_sub_article_object(article_object, xml_root, content, index):
     # generate a DOI value and create an article object
     sub_article_object = Article(sub_article_doi(article_object.doi, index))
+    # set the article id
+    sub_article_object.id = sub_article_id(index)
     # set the article type
     sub_article_object.article_type = ARTICLE_TYPE_MAP.get(
         content.get("type"), content.get("type")

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -260,6 +260,13 @@ class TestSubArticleData(unittest.TestCase):
         )
 
 
+class TestSubArticleId(unittest.TestCase):
+    def test_sub_article_id(self):
+        index = 0
+        expected = "sa0"
+        self.assertEqual(sub_article.sub_article_id(index), expected)
+
+
 class TestSubArticleDoi(unittest.TestCase):
     def test_sub_article_doi(self):
         article_doi = "10.7554/eLife.79713.1"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7569

When trying this out, the XML `<sub-article>` tag was missing the `@id` attribute, which is part of the DOI value, so here the `id` is assigned to the `Article` object to be used.