### PR TITLE
Remove history tag from PRC XML.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/transform.py
+++ b/elifecleaner/transform.py
@@ -4,7 +4,7 @@ import os
 import zipfile
 from elifetools import xmlio
 from elifetools import parseJATS as parser
-from elifecleaner import LOGGER, parse, zip_lib
+from elifecleaner import LOGGER, parse, prc, zip_lib
 
 
 WELLCOME_FUNDING_STATEMENT = "For the purpose of Open Access, the authors have applied a CC BY public copyright license to any Author Accepted Manuscript version arising from this submission."
@@ -215,9 +215,13 @@ def transform_xml_history_tags(root, soup, zip_file_name):
         display_channel_list,
     )
 
-    if article_type in ["correction", "editorial", "retraction"] or (
-        article_type == "article-commentary"
-        and "insight" in [value.lower() for value in display_channel_list if value]
+    if (
+        article_type in ["correction", "editorial", "retraction"]
+        or (
+            article_type == "article-commentary"
+            and "insight" in [value.lower() for value in display_channel_list if value]
+        )
+        or prc.is_xml_prc(root)
     ):
         LOGGER.info("%s transforming xml history tags", zip_file_name)
         # remove history tag

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -411,6 +411,53 @@ class TestTransformXmlHistoryTags(unittest.TestCase):
         )
         self.assertEqual(transform.xml_element_to_string(root_output), expected)
 
+    def test_transform_xml_history_tags_prc_article(self):
+        "test removing history tag from a Publish Review Curate (PRC) article"
+        # populate an ElementTree
+        xml_string = (
+            '<article article-type="research-article">'
+            "<front>"
+            "<journal-meta>"
+            '<journal-id journal-id-type="nlm-ta">__not_elife__</journal-id>'
+            '<issn publication-format="electronic" pub-type="epub">2050-084X</issn>'
+            "</journal-meta>"
+            "<article-meta>"
+            "<article-categories>"
+            '<subj-group subj-group-type="display-channel">'
+            "<subject>Test</subject>"
+            "</subj-group>"
+            "</article-categories>"
+            "<history>"
+            "<date/>"
+            "</history>"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        soup = parser.parse_xml(xml_string)
+        # invoke the function
+        root_output = transform.transform_xml_history_tags(root, soup, "test.zip")
+        # find the tag in the XML root returned which will have been altered
+        expected = (
+            '<?xml version="1.0" ?>'
+            '<article article-type="research-article">'
+            "<front>"
+            '<journal-meta><journal-id journal-id-type="nlm-ta">__not_elife__</journal-id>'
+            '<issn publication-format="electronic" pub-type="epub">2050-084X</issn>'
+            "</journal-meta>"
+            "<article-meta>"
+            "<article-categories>"
+            '<subj-group subj-group-type="display-channel">'
+            "<subject>Test</subject>"
+            "</subj-group>"
+            "</article-categories>"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        self.assertEqual(transform.xml_element_to_string(root_output), expected)
+
 
 class TestTransformXmlFunding(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8021

Also remove the `<history>` tag from Publish Review Curate (PRC) article XML.