### PR TITLE
assessment_terms.py module adds kwd and bold tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Clean and transform article submission files into a consistent format
 
 Install `imagemagick-dev` and `ghostscript` in order for `wand` Python module to open PDF files. Also, the imagemagick `policy.xml` file must be configured to allow reading of PDF files.
 
+## Configuration
+
+To use a YAML file of assessment terms in the `asessment_terms.py` module, set the constant `ASSESSMENT_TERMS_YAML` in the module to be the path to the YAML file on disk. The sample file `assessment_terms.yaml` in the code repository is not distributed as part of the library.
+
 ## License
 
 Licensed under [MIT](https://opensource.org/licenses/mit-license.php).

--- a/assessment_terms.yaml
+++ b/assessment_terms.yaml
@@ -1,0 +1,68 @@
+Compelling:
+  group:
+    evidence-strength
+  terms:
+    - compelling
+
+Convincing:
+  group:
+    evidence-strength
+  terms:
+    - convincing
+    - convincingly
+
+Exceptional:
+  group:
+    evidence-strength
+  terms:
+    - exceptional
+
+Fundamental:
+  group:
+    claim-importance
+  terms:
+    - fundamental
+
+Important:
+  group:
+    claim-importance
+  terms:
+    - important
+
+Inadequate:
+  group:
+    evidence-strength
+  terms:
+    - inadequate
+    - inadequately
+
+Incomplete:
+  group:
+    evidence-strength
+  terms:
+    - incomplete
+    - incompletely
+
+Landmark:
+  group:
+    claim-importance
+  terms:
+    - landmark
+
+Solid:
+  group:
+    evidence-strength
+  terms:
+    - solid
+
+Useful:
+  group:
+    claim-importance
+  terms:
+    - useful
+
+Valuable:
+  group:
+    claim-importance
+  terms:
+    - valuable

--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/assessment_terms.py
+++ b/elifecleaner/assessment_terms.py
@@ -1,0 +1,136 @@
+import re
+from xml.etree import ElementTree
+from xml.etree.ElementTree import SubElement
+import yaml
+from elifecleaner import LOGGER
+
+
+ASSESSMENT_TERMS_YAML = "assessment_terms.yaml"
+
+
+def load_yaml(file_path=None):
+    # load config from the file_path YAML file
+    if not file_path:
+        file_path = ASSESSMENT_TERMS_YAML
+    try:
+        with open(file_path, "r") as open_file:
+            return yaml.load(open_file.read(), Loader=yaml.FullLoader)
+    except:
+        LOGGER.exception(
+            "Exception in load_yaml for file_path: %s",
+            file_path,
+        )
+        return None
+
+
+def terms_data_from_yaml(file_path=None):
+    return load_yaml(file_path)
+
+
+def terms_data_by_terms(terms):
+    "return a list of terms data which match the terms"
+    terms_data = terms_data_from_yaml()
+    if not terms_data:
+        return {}
+    # case-insensitive term matching using set operations to return a dict of matched YAML terms
+    # if any of the supplied terms are found in the list of terms in the YAML then it is a hit
+    return {
+        term: data
+        for term, data in terms_data.items()
+        if set([term.lower() for term in terms]).intersection(
+            set([term.lower() for term in data.get("terms", [])])
+        )
+    }
+
+
+def terms_from_yaml():
+    "get a list of unique terms from the YAML file"
+    terms_data = terms_data_from_yaml()
+    if not terms_data:
+        return []
+    terms_list = []
+    for data in terms_data.values():
+        terms_list += data.get("terms", [])
+    return sorted(list(set(terms_list)))
+
+
+def add_assessment_terms(root):
+    "wrap specific terms with a bold tag in the body and add kwd tags"
+    body_tag = root.find(".//body")
+    if body_tag is not None:
+        for tag_index, child_tag in enumerate(body_tag.iterfind("*")):
+            # convert the tag to a string
+            xml_string = ElementTree.tostring(child_tag, encoding="utf-8")
+            # list of terms from the YAML file
+            terms = terms_from_yaml()
+            xml_string = xml_string_term_bold(xml_string.decode("utf-8"), terms)
+            # convert the XML string back to an element
+            new_child_tag = ElementTree.fromstring(xml_string)
+            # remove old tag
+            body_tag.remove(child_tag)
+            # insert the new tag
+            body_tag.insert(tag_index, new_child_tag)
+
+        terms = terms_from_yaml()
+        matched_terms = []
+        xml_string = ElementTree.tostring(body_tag, encoding="utf-8")
+        for term in terms:
+            term_match_groups = term_matches(xml_string.decode("utf-8"), term)
+            for matched_term in term_match_groups:
+                matched_terms.append(matched_term)
+
+        terms_data = terms_data_by_terms(matched_terms)
+
+        if terms_data:
+            front_stub_tag = root.find(".//front-stub")
+
+            # tags will be added in the order listed in the YAML file
+            group_to_kwd_group_tag_map = {}
+            for key, data in terms_data.items():
+                if data.get("group") in group_to_kwd_group_tag_map.keys():
+                    # reuse the kwd-group tag
+                    kwd_group_tag = group_to_kwd_group_tag_map.get(data.get("group"))
+                else:
+                    # create a new kwd-group tag
+                    kwd_group_tag = SubElement(front_stub_tag, "kwd-group")
+                    kwd_group_tag.set("kwd-group-type", data.get("group"))
+                    group_to_kwd_group_tag_map[data.get("group")] = kwd_group_tag
+                # add a kwd tag
+                kwd_tag = SubElement(kwd_group_tag, "kwd")
+                kwd_tag.text = key
+
+
+def term_match_pattern(term_text):
+    "regular expression to find mentions of a term"
+    return r"[\s\W](%s)\W" % (term_text)
+
+
+def term_matches(xml_string, term_text):
+    "get list of terms in text that are not already preceeded by the bold tag"
+    return re.findall(term_match_pattern(term_text), xml_string, flags=re.IGNORECASE)
+
+
+def xml_string_term_bold(xml_string, terms):
+    "wrap occurences of each term in the XML string with a <bold> tag"
+    open_tag = "<bold>"
+    close_tag = "</bold>"
+    for term in terms:
+        if not term:
+            continue
+        # look for term in the text but not preceeded by a bold open tag
+        term_match_groups = term_matches(xml_string, term)
+        for matched_term in term_match_groups:
+            safe_match_pattern = r"(?<!%s)(%s)(\W)" % (open_tag, matched_term)
+            replacement_pattern = r"%s\1%s\2" % (
+                open_tag,
+                close_tag,
+            )
+            xml_string = re.sub(
+                safe_match_pattern,
+                replacement_pattern,
+                xml_string,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+
+    return xml_string

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -5,7 +5,7 @@ from xml.etree.ElementTree import Element, SubElement
 from elifearticle.article import Article, Contributor, Role
 from docmaptools import parse as docmap_parse
 from jatsgenerator import build
-from elifecleaner import LOGGER, parse
+from elifecleaner import assessment_terms, LOGGER, parse
 
 XML_NAMESPACES = {
     "ali": "http://www.niso.org/schemas/ali/1.0/",
@@ -154,6 +154,10 @@ def format_content_json(content_json, article_object):
         sub_article_object = build_sub_article_object(
             article_object, xml_root, content, index
         )
+
+        # if editor-report, extra formatting for the abstract
+        if sub_article_object.article_type == "editor-report":
+            assessment_terms.add_assessment_terms(xml_root)
 
         data.append(
             {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ elifearticle==0.14.0
 jatsgenerator==0.5.0
 mock==4.0.3
 pytest==6.2.2
+PyYAML==5.4.1
 Wand==0.6.6
 coverage==6.4.2

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "elifetools",
         "elifearticle>=0.10.0",
         "jatsgenerator>=0.4.0",
+        "PyYAML>=5.4.1",
         "wand >= 0.5.2",
     ],
     url="https://github.com/elifesciences/elife-cleaner",

--- a/tests/test_assessment_terms.py
+++ b/tests/test_assessment_terms.py
@@ -1,0 +1,188 @@
+import unittest
+from xml.etree import ElementTree
+from mock import patch
+import yaml
+from elifetools import xmlio
+from elifecleaner import assessment_terms
+
+
+class TestLoadYaml(unittest.TestCase):
+    def test_load_yaml(self):
+        "load YAML file using the default"
+        result = assessment_terms.load_yaml()
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, dict))
+
+    def test_no_file(self):
+        "test if no file is supplied also uses the default"
+        result = assessment_terms.load_yaml(None)
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, dict))
+
+    @patch.object(yaml, "load")
+    def test_exception(self, mock_load):
+        "test an exception when loading the YAML file"
+        mock_load.side_effect = Exception("An exception")
+        result = assessment_terms.load_yaml()
+        self.assertEqual(result, None)
+
+
+class TestTermsDataByTerms(unittest.TestCase):
+    def setUp(self):
+        self.terms_data = {
+            "Beagle": {"group": "dog", "terms": ["beagle", "beagles"]},
+            "Dingo": {"group": "dog", "terms": ["dingo", "dingos"]},
+            "Dodo": {"group": "bird", "terms": ["dodo", "dodos"]},
+            "Parrot": {"group": "bird", "terms": ["parrot", "parrots"]},
+        }
+
+    @patch.object(assessment_terms, "terms_data_from_yaml")
+    def test_terms_data_by_terms(self, mock_terms_data):
+        mock_terms_data.return_value = self.terms_data
+        terms = ["dodo", "dodos", "DINGO"]
+        expected_keys = ["Dingo", "Dodo"]
+        result = assessment_terms.terms_data_by_terms(terms)
+        self.assertEqual(sorted(result.keys()), sorted(expected_keys))
+
+    @patch.object(assessment_terms, "terms_data_from_yaml")
+    def test_no_match(self, mock_terms_data):
+        mock_terms_data.return_value = self.terms_data
+        terms = ["penguin"]
+        expected_keys = []
+        result = assessment_terms.terms_data_by_terms(terms)
+        self.assertEqual(sorted(result.keys()), sorted(expected_keys))
+
+    @patch.object(assessment_terms, "terms_data_from_yaml")
+    def test_no_data(self, mock_terms_data):
+        mock_terms_data.return_value = None
+        terms = ["penguin"]
+        expected_keys = []
+        result = assessment_terms.terms_data_by_terms(terms)
+        self.assertEqual(sorted(result.keys()), sorted(expected_keys))
+
+    @patch.object(assessment_terms, "terms_data_from_yaml")
+    def test_none(self, mock_terms_data):
+        mock_terms_data.return_value = None
+        terms = ["dodo"]
+        expected_keys = []
+        result = assessment_terms.terms_data_by_terms(terms)
+        self.assertEqual(sorted(result.keys()), sorted(expected_keys))
+
+
+class TestTermsFromYaml(unittest.TestCase):
+    def test_terms_from_yaml(self):
+        self.assertTrue(len(assessment_terms.terms_from_yaml()) > 0)
+
+    @patch.object(assessment_terms, "terms_data_from_yaml")
+    def test_yaml_none(self, mock_terms_data):
+        mock_terms_data.return_value = None
+        self.assertEqual(assessment_terms.terms_from_yaml(), [])
+
+
+class TestAddAssessmentTerms(unittest.TestCase):
+    def setUp(self):
+        # register XML namespaces
+        xmlio.register_xmlns()
+
+    def test_add_assessment_terms(self):
+        "test editor-report example with specific terms in the abstract"
+        xml_root = ElementTree.fromstring(
+            b'<article xmlns:xlink="http://www.w3.org/1999/xlink"><front-stub><title-group>'
+            b"<article-title>eLife assessment</article-title>"
+            b"</title-group></front-stub>"
+            b"<body>"
+            b"<p>Landmark convincing evaluation "
+            b'(<ext-link xlink:href="https://example.org"/>), '
+            b"convincingly compelling if "
+            b"incompletely unconvincing (convincingly).</p>"
+            b"</body>"
+            b"</article>"
+        )
+
+        expected_xml = (
+            b'<article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<front-stub>"
+            b"<title-group>"
+            b"<article-title>eLife assessment</article-title>"
+            b"</title-group>"
+            b'<kwd-group kwd-group-type="evidence-strength">'
+            b"<kwd>Compelling</kwd>"
+            b"<kwd>Convincing</kwd>"
+            b"<kwd>Incomplete</kwd>"
+            b"</kwd-group>"
+            b'<kwd-group kwd-group-type="claim-importance">'
+            b"<kwd>Landmark</kwd>"
+            b"</kwd-group>"
+            b"</front-stub>"
+            b"<body><p><bold>Landmark</bold> <bold>convincing</bold> evaluation "
+            b'(<ext-link xlink:href="https://example.org" />), '
+            b"<bold>convincingly</bold> <bold>compelling</bold> if "
+            b"<bold>incompletely</bold> unconvincing (<bold>convincingly</bold>).</p>"
+            b"</body>"
+            b"</article>"
+        )
+
+        assessment_terms.add_assessment_terms(xml_root)
+        rough_xml_string = ElementTree.tostring(xml_root, "utf-8")
+        # assert
+        self.assertEqual(rough_xml_string, expected_xml)
+
+    def test_non_p_tag(self):
+        "test for a tag which is not a p tag"
+        xml_string = (
+            b"<article>"
+            b"<front-stub>"
+            b"<title-group>"
+            b"<article-title>eLife assessment</article-title>"
+            b"</title-group>"
+            b"</front-stub>"
+            b"<body>"
+            b"<sec>Landmark</sec>"
+            b"</body>"
+            b"</article>"
+        )
+        expected_xml = (
+            b"<article>"
+            b"<front-stub>"
+            b"<title-group>"
+            b"<article-title>eLife assessment</article-title>"
+            b"</title-group>"
+            b'<kwd-group kwd-group-type="claim-importance">'
+            b"<kwd>Landmark</kwd>"
+            b"</kwd-group>"
+            b"</front-stub>"
+            b"<body><sec><bold>Landmark</bold></sec></body>"
+            b"</article>"
+        )
+        xml_root = ElementTree.fromstring(xml_string)
+        assessment_terms.add_assessment_terms(xml_root)
+        rough_xml_string = ElementTree.tostring(xml_root, "utf-8")
+        self.assertEqual(rough_xml_string, expected_xml)
+
+
+class TestXmlStringTermBold(unittest.TestCase):
+    def test_xml_string_term_bold(self):
+        test_data = {
+            "xml_string": ("<p>In Author Response image 1, yes response.</p>"),
+            "terms": ["response"],
+            "expected": (
+                "<p>In "
+                "Author <bold>Response</bold> image 1, yes <bold>response</bold>.</p>"
+            ),
+        }
+        modified_xml_string = assessment_terms.xml_string_term_bold(
+            test_data.get("xml_string"), test_data.get("terms")
+        )
+        self.assertEqual(modified_xml_string, test_data.get("expected"))
+
+    def test_blank_terms(self):
+        "test for blank or missing terms"
+        test_data = {
+            "xml_string": ("<p>In Author Response image 1, yes response.</p>"),
+            "terms": ["", None],
+            "expected": ("<p>In " "Author Response image 1, yes response.</p>"),
+        }
+        modified_xml_string = assessment_terms.xml_string_term_bold(
+            test_data.get("xml_string"), test_data.get("terms")
+        )
+        self.assertEqual(modified_xml_string, test_data.get("expected"))

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -434,6 +434,55 @@ class TestFormatContentJson(unittest.TestCase):
         self.assertIsNotNone(body_tag)
         self.assertEqual(body_tag.find("p").text, "Test evaluation summary.")
 
+    def test_editor_report(self):
+        "test editor-report example with specific terms in the abstract"
+        article_object = Article("10.7554/eLife.79713.1")
+        content_json = [
+            {
+                "type": "evaluation-summary",
+                "html": (
+                    b"<p><strong>eLife assessment</strong></p>"
+                    b"<p>Landmark convincing evaluation, "
+                    b"convincingly compelling if "
+                    b"incompletely.</p>"
+                ),
+            },
+        ]
+        expected_xml = (
+            b"<root>"
+            b"<front-stub>"
+            b"<title-group>"
+            b"<article-title>eLife assessment</article-title>"
+            b"</title-group>"
+            b'<kwd-group kwd-group-type="evidence-strength">'
+            b"<kwd>Compelling</kwd>"
+            b"<kwd>Convincing</kwd>"
+            b"<kwd>Incomplete</kwd>"
+            b"</kwd-group>"
+            b'<kwd-group kwd-group-type="claim-importance">'
+            b"<kwd>Landmark</kwd>"
+            b"</kwd-group>"
+            b"</front-stub>"
+            b"<body>"
+            b"<p><bold>Landmark</bold> <bold>convincing</bold> evaluation, "
+            b"<bold>convincingly</bold> <bold>compelling</bold> if "
+            b"<bold>incompletely</bold>.</p>"
+            b"</body>"
+            b"</root>"
+        )
+        sub_article_data = sub_article.format_content_json(content_json, article_object)
+        self.assertEqual(
+            sub_article_data[0].get("article").doi, "10.7554/eLife.79713.1.sa0"
+        )
+        self.assertEqual(sub_article_data[0].get("article").title, "eLife assessment")
+        self.assertEqual(
+            sub_article_data[0].get("article").article_type, "editor-report"
+        )
+        rough_xml_string = ElementTree.tostring(
+            sub_article_data[0].get("xml_root"), "utf-8"
+        )
+        self.assertEqual(rough_xml_string, expected_xml)
+
 
 class TestGenerate(unittest.TestCase):
     def test_generate(self):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8176

When formatting `<sub-article>` data, if it is type `editor-report`, search for terms to wrap in `<bold>` tags in the `<body>`, and add `<kwd>` tags for them.