### PR TITLE
Change add_assessment_terms() potential bug.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.30.0"
+__version__ = "0.30.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/assessment_terms.py
+++ b/elifecleaner/assessment_terms.py
@@ -58,11 +58,22 @@ def add_assessment_terms(root):
     "wrap specific terms with a bold tag in the body and add kwd tags"
     body_tag = root.find(".//body")
     if body_tag is not None:
+        # list of terms from the YAML file
+        terms = terms_from_yaml()
+
+        # find matched terms for adding kwd tags later on
+        matched_terms = []
+        xml_string = ElementTree.tostring(body_tag, encoding="utf-8")
+        for term in terms:
+            term_match_groups = term_matches(xml_string.decode("utf-8"), term)
+            for matched_term in term_match_groups:
+                matched_terms.append(matched_term)
+
+        # wrap terms with bold tags
         for tag_index, child_tag in enumerate(body_tag.iterfind("*")):
             # convert the tag to a string
             xml_string = ElementTree.tostring(child_tag, encoding="utf-8")
-            # list of terms from the YAML file
-            terms = terms_from_yaml()
+            # wrap terms with bold tag
             xml_string = xml_string_term_bold(xml_string.decode("utf-8"), terms)
             # convert the XML string back to an element
             new_child_tag = ElementTree.fromstring(xml_string)
@@ -71,14 +82,7 @@ def add_assessment_terms(root):
             # insert the new tag
             body_tag.insert(tag_index, new_child_tag)
 
-        terms = terms_from_yaml()
-        matched_terms = []
-        xml_string = ElementTree.tostring(body_tag, encoding="utf-8")
-        for term in terms:
-            term_match_groups = term_matches(xml_string.decode("utf-8"), term)
-            for matched_term in term_match_groups:
-                matched_terms.append(matched_term)
-
+        # add kwd-group and kwd tags
         terms_data = terms_data_by_terms(matched_terms)
 
         if terms_data:

--- a/tests/test_assessment_terms.py
+++ b/tests/test_assessment_terms.py
@@ -127,6 +127,40 @@ class TestAddAssessmentTerms(unittest.TestCase):
         # assert
         self.assertEqual(rough_xml_string, expected_xml)
 
+    def test_multiple_p_tags(self):
+        "test editor-report with multiple p tags in the abstract"
+        xml_root = ElementTree.fromstring(
+            b"<sub-article><front-stub><title-group>"
+            b"<article-title>eLife assessment</article-title>"
+            b"</title-group></front-stub>"
+            b"<body>"
+            b"<p>Landmark.</p>"
+            b"<p><bold>Important</bold>!</p>"
+            b"</body>"
+            b"</sub-article>"
+        )
+
+        expected_xml = (
+            b"<sub-article>"
+            b"<front-stub>"
+            b"<title-group><article-title>eLife assessment</article-title></title-group>"
+            b'<kwd-group kwd-group-type="claim-importance">'
+            b"<kwd>Important</kwd>"
+            b"<kwd>Landmark</kwd>"
+            b"</kwd-group>"
+            b"</front-stub>"
+            b"<body>"
+            b"<p><bold>Landmark</bold>.</p>"
+            b"<p><bold>Important</bold>!</p>"
+            b"</body>"
+            b"</sub-article>"
+        )
+
+        assessment_terms.add_assessment_terms(xml_root)
+        rough_xml_string = ElementTree.tostring(xml_root, "utf-8")
+        # assert
+        self.assertEqual(rough_xml_string, expected_xml)
+
     def test_non_p_tag(self):
         "test for a tag which is not a p tag"
         xml_string = (

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -445,6 +445,7 @@ class TestFormatContentJson(unittest.TestCase):
                     b"<p>Landmark convincing evaluation, "
                     b"convincingly compelling if "
                     b"incompletely.</p>"
+                    b"<p>And important.</p>"
                 ),
             },
         ]
@@ -460,6 +461,7 @@ class TestFormatContentJson(unittest.TestCase):
             b"<kwd>Incomplete</kwd>"
             b"</kwd-group>"
             b'<kwd-group kwd-group-type="claim-importance">'
+            b"<kwd>Important</kwd>"
             b"<kwd>Landmark</kwd>"
             b"</kwd-group>"
             b"</front-stub>"
@@ -467,6 +469,7 @@ class TestFormatContentJson(unittest.TestCase):
             b"<p><bold>Landmark</bold> <bold>convincing</bold> evaluation, "
             b"<bold>convincingly</bold> <bold>compelling</bold> if "
             b"<bold>incompletely</bold>.</p>"
+            b"<p>And <bold>important</bold>.</p>"
             b"</body>"
             b"</root>"
         )


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8176

Improvement to code merged in PR https://github.com/elifesciences/elife-cleaner/pull/80

After testing in a workflow, the `<kwd>` tags did not appear as expected. Test scenarios do not produce the same bug, but the `add_assessment_terms()` can be changed to produce the same or better output.