### PR TITLE
Tag added in particular order in add_version_doi()

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -1,5 +1,5 @@
 import re
-from xml.etree.ElementTree import SubElement
+from xml.etree.ElementTree import Element, SubElement
 from docmaptools import parse as docmap_parse
 from elifecleaner import LOGGER
 
@@ -187,8 +187,14 @@ def add_version_doi(root, doi, identifier=None):
         )
         return root
     # add article-id tag
-    article_id_tag = SubElement(article_meta_tag, "article-id")
+    article_id_tag = Element("article-id")
     article_id_tag.set("pub-id-type", "doi")
     article_id_tag.set("specific-use", "version")
     article_id_tag.text = doi
+    # insert the new tag into the XML after the last article-id tag
+    insert_index = 1
+    for tag_index, tag in enumerate(article_meta_tag.findall("*")):
+        if tag.tag == "article-id":
+            insert_index = tag_index + 1
+    article_meta_tag.insert(insert_index, article_id_tag)
     return root

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -395,6 +395,35 @@ class TestAddVersionDoi(unittest.TestCase):
         root_output = prc.add_version_doi(root, self.doi, self.identifier)
         self.assertEqual(ElementTree.tostring(root_output), expected)
 
+    def test_add_version_doi_in_order(self):
+        "test the new article-id tag is added in a particular order"
+        xml_string = (
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            "<article-id />"
+            "<open-access>YES</open-access>"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        expected = (
+            b"<article>"
+            b"<front>"
+            b"<article-meta>"
+            b"<article-id />"
+            b'<article-id pub-id-type="doi" specific-use="version">'
+            b"10.7554/eLife.1234567890.5"
+            b"</article-id>"
+            b"<open-access>YES</open-access>"
+            b"</article-meta>"
+            b"</front>"
+            b"</article>"
+        )
+        root_output = prc.add_version_doi(root, self.doi, self.identifier)
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+
     def test_no_article_meta(self):
         "test if no article-meta tag is in the XML"
         xml_string = "<article />"


### PR DESCRIPTION
Improve the tag order when adding an `<article-id>` tag containing a version DOI so it is direclty below the last `<article-id>` tag found in the `<article-meta>`.

Re issue https://github.com/elifesciences/issues/issues/7893