### PR TITLE
Only add editor type contributors to editor-report

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -96,11 +96,16 @@ def sub_article_doi(article_doi, index):
     return "%s.%s" % (article_doi, sub_article_id(index))
 
 
+EDITOR_REPORT_CONTRIB_TYPES = ["editor"]
+
+
 def sub_article_contributors(article_object, sub_article_object):
     "add contributors to the sub-article from the parent article depending on the article type"
     if sub_article_object.article_type == "editor-report":
         # add editors of the article as authors of the sub-article
         for editor in article_object.editors:
+            if editor.contrib_type not in EDITOR_REPORT_CONTRIB_TYPES:
+                continue
             author = copy.copy(editor)
             author.contrib_type = "author"
             if not author.roles:

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -293,6 +293,9 @@ class TestSubArticleContributors(unittest.TestCase):
         self.article_object.contributors.append(author)
         editor = Contributor("editor", "Itor", "Ed")
         self.article_object.editors.append(editor)
+        # reviewer contrib_type will not be added to an editor-report
+        reviewer = Contributor("reviewer", "Ewer", "Revi")
+        self.article_object.editors.append(reviewer)
 
     def test_editor_report(self):
         "test editor-report article type"


### PR DESCRIPTION
Restrict the type of editor contributors added to an `editor-report` `<sub-article>` to be the ones of type listed in the constant `EDITOR_REPORT_CONTRIB_TYPES`.

Re issue https://github.com/elifesciences/issues/issues/8284