### PR TITLE
Use Article version_doi when available for new DOI

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -126,7 +126,11 @@ def sub_article_contributors(article_object, sub_article_object):
 
 def build_sub_article_object(article_object, xml_root, content, index):
     # generate a DOI value and create an article object
-    sub_article_object = Article(sub_article_doi(article_object.doi, index))
+    if article_object.version_doi:
+        doi_base = article_object.version_doi
+    else:
+        doi_base = article_object.doi
+    sub_article_object = Article(sub_article_doi(doi_base, index))
     # set the article id
     sub_article_object.id = sub_article_id(index)
     # set the article type

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -334,7 +334,8 @@ class TestSubArticleContributors(unittest.TestCase):
 class TestBuildSubArticleObject(unittest.TestCase):
     def test_build_sub_article_object(self):
         "test review-article example"
-        article_object = Article("10.7554/eLife.79713.1")
+        article_object = Article("10.7554/eLife.79713")
+        article_object.version_doi = "10.7554/eLife.79713.1"
         xml_root = ElementTree.fromstring(
             b"<article><front-stub><title-group>"
             b"<article-title>Title</article-title>"
@@ -351,14 +352,14 @@ class TestBuildSubArticleObject(unittest.TestCase):
 
     def test_minimal(self):
         "test minimal, incomplete, arguments supplied"
-        article_object = Article("10.7554/eLife.79713.1")
+        article_object = Article("10.7554/eLife.79713")
         xml_root = Element("root")
         content = {}
         index = 0
         sub_article_object = sub_article.build_sub_article_object(
             article_object, xml_root, content, index
         )
-        self.assertEqual(sub_article_object.doi, "10.7554/eLife.79713.1.sa0")
+        self.assertEqual(sub_article_object.doi, "10.7554/eLife.79713.sa0")
         self.assertEqual(sub_article_object.title, None)
         self.assertEqual(len(sub_article_object.contributors), 0)
 


### PR DESCRIPTION
If the `Article` has a `version_doi`, then use it as the base for generating a DOI for a peer review `<sub-article>`, otherwise use the `doi` property as it was doing previously.

Re issue https://github.com/elifesciences/issues/issues/8279