### PR TITLE
Only keep content json items which have html.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -154,6 +154,8 @@ def format_content_json(content_json, article_object):
     data = []
     # parse html to xml
     content_json = docmap_parse.transform_docmap_content(content_json)
+    # only keep items which have html
+    content_json = [content for content in content_json if content.get("html")]
     # reorder the articles
     content_json = reorder_content_json(content_json)
     # create an article for each

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -25,6 +25,7 @@ ARTICLE_TITLES = [
 ]
 
 CONTENT_JSON = [
+    {"type": "preprint"},
     {
         "type": "evaluation-summary",
         "html": b"<p><strong>%s</strong></p><p>Test evaluation summary.</p>"


### PR DESCRIPTION
To fix a bug with real data, when docmap output includes a preprint action, it has no `html`; later this causes problems so remove these unwanted content items early.