### PR TITLE
Transform fig

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/fig.py
+++ b/elifecleaner/fig.py
@@ -1,0 +1,376 @@
+import re
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, SubElement
+from elifecleaner import LOGGER, utils
+
+
+def inf_file_identifier(inf_file_name):
+    "specific part of an inline graphic file name, e.g. inf1 in elife-70493-inf1.png"
+    return inf_file_name.rsplit(".", 1)[0].rsplit("-", 1)[-1]
+
+
+def fig_file_name_identifier(sub_article_id, fig_index):
+    "create the unique portion of a fig file name"
+    return "%s-fig%s" % (sub_article_id, fig_index)
+
+
+def fig_id(sub_article_id, fig_index):
+    "create an id attribute for a fig tag"
+    return "%sfig%s" % (sub_article_id, fig_index)
+
+
+def fig_file_name(inf_file_name, sub_article_id, fig_index):
+    "from inf file name create a new fig file name"
+    return inf_file_name.replace(
+        inf_file_identifier(inf_file_name), "%s-fig%s" % (sub_article_id, fig_index)
+    )
+
+
+FIG_LABEL_CONTENT_PATTERN = r"[A-Za-z ]+ image [0-9]+?\.{0,1}"
+
+
+def match_fig_label_content(content):
+    "check if the content is a label for a figure"
+    return bool(re.match(FIG_LABEL_CONTENT_PATTERN, content)) if content else False
+
+
+def is_p_label(tag, sub_article_id, p_tag_index, identifier):
+    "check if the p tag contents is a label"
+    label = None
+    if tag.find("bold") is not None:
+        label = tag.find("bold").text
+        LOGGER.info(
+            '%s potential label "%s" in p tag %s of id %s',
+            identifier,
+            label,
+            p_tag_index,
+            sub_article_id,
+        )
+    return match_fig_label_content(label)
+
+
+def is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier):
+    "check if the p tag contains only an inline-graphic tag"
+    # simple check for a tag first
+    if tag.find("inline-graphic") is None:
+        LOGGER.info(
+            "%s no inline-graphic tag found in p tag %s of id %s",
+            identifier,
+            p_tag_index,
+            sub_article_id,
+        )
+        return False
+    # check if the p tag contains an inline-grpahic only, ignoring whitespace
+    if (
+        tag.find("inline-graphic") is not None
+        and (not tag.text or not tag.text.rstrip())
+        and (
+            not tag.find("inline-graphic").tail
+            or not tag.find("inline-graphic").tail.rstrip()
+        )
+    ):
+        LOGGER.info(
+            "%s only inline-graphic tag found in p tag %s of id %s",
+            identifier,
+            p_tag_index,
+            sub_article_id,
+        )
+        return True
+    # default return None
+    return None
+
+
+def fig_tag_index_groups(body_tag, sub_article_id, identifier):
+    "iterate through the tags in body_tag and find groups of tags to be converted to a fig"
+    fig_index_groups = []
+    if not body_tag:
+        return fig_index_groups
+    label_index = None
+    caption_index = None
+    for tag_index, child_tag in enumerate(body_tag.iterfind("*")):
+        if child_tag.tag == "p":
+            if label_index is None:
+                # match figure label
+                if is_p_label(child_tag, sub_article_id, tag_index, identifier):
+                    label_index = tag_index
+                    LOGGER.info(
+                        "%s label p tag index %s of id %s",
+                        identifier,
+                        label_index,
+                        sub_article_id,
+                    )
+            elif label_index is not None and caption_index is None:
+                # look for optional caption
+                if not is_p_inline_graphic(
+                    child_tag, sub_article_id, tag_index, identifier
+                ):
+                    caption_index = tag_index
+                    # loop to the next p tag
+                    continue
+                # if no caption found, check this p tag for an inline-graphic below
+                caption_index = False
+            if label_index is not None and caption_index is not None:
+                # look for inline graphic to be converted to fig
+                if is_p_inline_graphic(
+                    child_tag, sub_article_id, tag_index, identifier
+                ):
+                    # add to the fig index group
+                    fig_p_data = {
+                        "label_index": label_index,
+                        "caption_index": caption_index,
+                        "inline_graphic_index": tag_index,
+                    }
+                    fig_index_groups.append(fig_p_data)
+                # reset the indexes
+                label_index = None
+                caption_index = None
+        else:
+            # if is not a p tag, reset the indexes
+            label_index = None
+            caption_index = None
+    return fig_index_groups
+
+
+def strip_tag_text(tag):
+    "remove whitespace to the left of the child tag if present"
+    if isinstance(tag, Element) and tag.text is not None and not tag.text.rstrip():
+        tag.text = None
+
+
+def strip_tag_tail(tag):
+    "remove whitespace to the right of the tag if present"
+    if isinstance(tag, Element) and tag.tail is not None and not tag.tail.rstrip():
+        tag.tail = None
+
+
+def remove_tag_attributes(tag):
+    "remove attributes from the tag"
+    if not isinstance(tag, Element):
+        return
+    attribute_names = [name for name in tag.attrib]
+    for attrib_name in attribute_names:
+        del tag.attrib[attrib_name]
+
+
+def inline_graphic_tag_from_tag(tag):
+    "get the inline-graphic tag from the parent tag"
+    strip_tag_text(tag)
+    inline_graphic_tag = tag.find("inline-graphic")
+    strip_tag_tail(inline_graphic_tag)
+    return inline_graphic_tag
+
+
+def sub_article_tag_parts(sub_article_root):
+    "return the id and body tag from a sub-article tag"
+    sub_article_id = sub_article_root.get("id")
+    body_tag = sub_article_root.find("body")
+    return sub_article_id, body_tag
+
+
+def inline_graphic_hrefs(sub_article_root, identifier):
+    "get inline-graphic href values"
+    sub_article_id, body_tag = sub_article_tag_parts(sub_article_root)
+    href_list = []
+    if body_tag is not None:
+        # match paragraphs with fig data in them and record the tag indexes
+        fig_index_groups = fig_tag_index_groups(body_tag, sub_article_id, identifier)
+        for group in fig_index_groups:
+            if group.get("inline_graphic_index"):
+                inline_graphic_p = body_tag[group.get("inline_graphic_index")]
+                inline_graphic_tag = inline_graphic_tag_from_tag(inline_graphic_p)
+                image_href = utils.xlink_href(inline_graphic_tag)
+                if image_href:
+                    href_list.append(image_href)
+    return href_list
+
+
+def graphic_hrefs(sub_article_root, identifier):
+    "get graphic href values"
+    sub_article_id, body_tag = sub_article_tag_parts(sub_article_root)
+    href_list = []
+    if body_tag is not None:
+        for graphic_tag in body_tag.findall(".//graphic"):
+            image_href = utils.xlink_href(graphic_tag)
+            if image_href:
+                href_list.append(image_href)
+    return href_list
+
+
+def set_label_tag(parent, body_tag, label_index):
+    "add a label tag to the parent"
+    # insert tags into original inline-graphic
+    label_tag = SubElement(parent, "label")
+    # copy content from the label_index p tag
+    label_tag.text = body_tag[label_index].find("bold").text
+
+
+def split_title_parts(xml_string):
+    "split the XML string into parts to be processed by caption_title_paragraph()"
+    title_parts = []
+    tag_match_pattern = re.compile(r"(<.*?>)")
+    match_tag_groups = tag_match_pattern.split(xml_string)
+    string_part = ""
+    for tag_group in match_tag_groups:
+        if "." in tag_group and "<" not in tag_group:
+            if tag_group == ".":
+                dot_parts = ["."]
+            else:
+                dot_parts = tag_group.split(".")
+
+            for dot_index, dot_part in enumerate(dot_parts):
+                suffix = ""
+                if dot_index + 1 < len(dot_parts):
+                    suffix = "."
+                string_part += "%s%s" % (dot_part, suffix)
+                title_parts.append(string_part)
+                string_part = ""
+        else:
+            string_part += tag_group
+    # append the final content
+    if title_parts:
+        title_parts[-1] += string_part
+
+    return title_parts
+
+
+def title_paragraph_content(string_list):
+    "from list of strings repair inline formatting tags and split into title and paragraph"
+    # check for nested inline formatting tags
+    title_content = ""
+    content_remainders = []
+    for title_part in string_list:
+        if not title_content:
+            title_content += title_part
+            continue
+        open_tag_count = title_content.count(utils.open_tag("italic"))
+        close_tag_count = title_content.count(utils.close_tag("italic"))
+        open_bold_tag_count = title_content.count(utils.open_tag("bold"))
+        close_bold_tag_count = title_content.count(utils.close_tag("bold"))
+        open_ext_link_tag_count = title_content.count(
+            utils.open_tag("ext-link").rstrip(">")
+        )
+        close_ext_link_tag_count = title_content.count(utils.close_tag("ext-link"))
+        if (
+            open_tag_count != close_tag_count
+            or open_bold_tag_count != close_bold_tag_count
+            or open_ext_link_tag_count != close_ext_link_tag_count
+        ):
+            title_content += title_part
+        else:
+            content_remainders.append(title_part)
+    title_content = title_content.lstrip()
+    paragraph_content = None
+    if content_remainders:
+        paragraph_content = "".join(content_remainders)
+    return title_content, paragraph_content
+
+
+def caption_title_paragraph(tag):
+    "split the content into title and optional paragraph for a fig caption"
+    xml_string = ElementTree.tostring(tag)
+    if isinstance(xml_string, bytes):
+        xml_string = str(xml_string, encoding="utf-8")
+
+    # split the string into parts
+    string_list = split_title_parts(xml_string)
+
+    title_content, paragraph_content = title_paragraph_content(string_list)
+
+    # fix enclosing tags
+    if paragraph_content:
+        title_content = "%s</p>" % title_content
+        paragraph_content = "<p %s>%s" % (
+            utils.namespace_string(),
+            paragraph_content.lstrip(),
+        )
+    # parse XML string back into an Element
+    caption_title_p_tag = ElementTree.fromstring(title_content)
+    caption_paragraph_p_tag = None
+    if paragraph_content:
+        caption_paragraph_p_tag = ElementTree.fromstring(paragraph_content)
+
+    return caption_title_p_tag, caption_paragraph_p_tag
+
+
+def set_caption_tag(parent, body_tag, caption_index):
+    "add a caption tag to the parent"
+    caption_tag = SubElement(parent, "caption")
+
+    # split into title and p tag portions
+    caption_title_p_tag, caption_paragraph_p_tag = caption_title_paragraph(
+        body_tag[caption_index]
+    )
+
+    caption_title_tag = SubElement(caption_tag, "title")
+    caption_title_tag.text = caption_title_p_tag.text
+    # handle if there are child tags in the title
+    for child_tag in caption_title_p_tag.iterfind("*"):
+        caption_title_tag.append(child_tag)
+        caption_title_tag.tail = caption_title_p_tag.tail
+    if caption_paragraph_p_tag is not None and caption_paragraph_p_tag.text:
+        caption_p_tag = SubElement(caption_tag, "p")
+        caption_p_tag.text = caption_paragraph_p_tag.text
+        # handle if there are child tags in the caption
+        for child_tag in caption_paragraph_p_tag.iterfind("*"):
+            caption_p_tag.append(child_tag)
+            caption_p_tag.tail = caption_paragraph_p_tag.tail
+
+
+def set_graphic_tag(parent, image_href, new_file_name):
+    "add a graphic tag to the parent"
+    graphic_tag = SubElement(parent, "graphic")
+    graphic_tag.set("mimetype", "image")
+    graphic_tag.set("mime-subtype", utils.file_extension(image_href))
+    graphic_tag.set("{http://www.w3.org/1999/xlink}href", new_file_name)
+
+
+def transform_fig_group(body_tag, fig_index, fig_group, sub_article_id):
+    "transform one set of p tags into fig tags as specified in the fig_group dict"
+    inline_graphic_p_tag = body_tag[fig_group.get("inline_graphic_index")]
+    inline_graphic_tag = inline_graphic_tag_from_tag(inline_graphic_p_tag)
+    image_href = utils.xlink_href(inline_graphic_tag)
+
+    # insert tags into original inline-graphic
+    set_label_tag(inline_graphic_p_tag, body_tag, fig_group.get("label_index"))
+
+    # caption
+    if fig_group.get("caption_index"):
+        set_caption_tag(inline_graphic_p_tag, body_tag, fig_group.get("caption_index"))
+
+    # rename the image file
+    new_file_name = fig_file_name(image_href, sub_article_id, fig_index)
+
+    # graphic tag
+    set_graphic_tag(inline_graphic_p_tag, image_href, new_file_name)
+
+    # convert inline-graphic p tag to a fig tag and remove attributes
+    inline_graphic_p_tag.tag = "fig"
+    inline_graphic_p_tag.set("id", fig_id(sub_article_id, fig_index))
+
+    # delete the old inline-graphic tag
+    inline_graphic_p_tag.remove(inline_graphic_tag)
+
+    # remove the old p tags
+    if fig_group.get("caption_index"):
+        del body_tag[fig_group.get("caption_index")]
+    del body_tag[fig_group.get("label_index")]
+
+
+def transform_fig_groups(body_tag, fig_index_groups, sub_article_id):
+    "transform p tags in the body_tag to fig tags as listed in fig_index_groups"
+    # transform the fig tags in reverse order
+    fig_index = len(fig_index_groups)
+    for fig_group in reversed(fig_index_groups):
+        transform_fig_group(body_tag, fig_index, fig_group, sub_article_id)
+        # decrement the fig index
+        fig_index -= 1
+
+
+def transform_fig(sub_article_root, identifier):
+    "transform inline-graphic tags and related p tags into a fig tag"
+    sub_article_id, body_tag = sub_article_tag_parts(sub_article_root)
+    if body_tag is not None:
+        # match paragraphs with fig data in them and record the tag indexes
+        fig_index_groups = fig_tag_index_groups(body_tag, sub_article_id, identifier)
+        transform_fig_groups(body_tag, fig_index_groups, sub_article_id)
+    return sub_article_root

--- a/elifecleaner/parse.py
+++ b/elifecleaner/parse.py
@@ -250,7 +250,7 @@ def check_art_file(files, identifier):
         file_data for file_data in files if file_data.get("file_type") == "art_file"
     ]
     file_extensions = [
-        file_data.get("upload_file_nm").rsplit(".", 1)[-1]
+        utils.file_extension(file_data.get("upload_file_nm"))
         for file_data in art_files
         if file_data.get("upload_file_nm")
     ]

--- a/elifecleaner/utils.py
+++ b/elifecleaner/utils.py
@@ -6,6 +6,13 @@ def pad_msid(msid):
     return "{:05d}".format(int(msid))
 
 
+def file_extension(file_name):
+    "parse file extension from file name"
+    if not file_name:
+        return None
+    return file_name.rsplit(".", 1)[-1]
+
+
 # match ascii characters from decimal 0 to 31, as hexidecimal character entitiy strings
 # e.g. &#x001D; or &#x01;
 CONTROL_CHARACTER_ENTITY_MATCH_PATTERN = r"&#x0{0,2}[0-1][0-9A-Fa-f];"
@@ -37,3 +44,39 @@ def replace_control_characters(string):
     for char in list(set(match_control_characters(string))):
         string = string.replace(char, CONTROL_CHARACTER_ENTITY_REPLACEMENT)
     return string
+
+
+def xlink_href(tag):
+    "return the xlink:href attribute of the tag"
+    return tag.get("{http://www.w3.org/1999/xlink}href")
+
+
+def open_tag(tag_name, attr=None):
+    "XML string for an open tag"
+    if not attr:
+        return "<%s>" % tag_name
+    attr_values = []
+    for name, value in sorted(attr.items()):
+        attr_values.append('%s="%s"' % (name, value))
+    return "<%s %s>" % (tag_name, " ".join(attr_values))
+
+
+def close_tag(tag_name):
+    "XML string for a close tag"
+    return "</%s>" % tag_name
+
+
+NAMESPACE_MAP = {
+    "xmlns:mml": "http://www.w3.org/1998/Math/MathML",
+    "xmlns:xlink": "http://www.w3.org/1999/xlink",
+}
+
+
+def namespace_string():
+    "return a string of XML namespaces"
+    return " ".join(
+        [
+            '%s="%s"' % (attrib_name, attrib_value)
+            for attrib_name, attrib_value in NAMESPACE_MAP.items()
+        ]
+    )

--- a/elifecleaner/video_xml.py
+++ b/elifecleaner/video_xml.py
@@ -4,14 +4,9 @@ from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 from elifearticle.article import ArticleDate
 from elifecleaner import parse
-from elifecleaner.utils import pad_msid
+from elifecleaner.utils import NAMESPACE_MAP, pad_msid
 
 JOURNAL_ID_TYPES = ["nlm-ta", "publisher-id"]
-
-NAMESPACE_MAP = {
-    "xmlns:mml": "http://www.w3.org/1998/Math/MathML",
-    "xmlns:xlink": "http://www.w3.org/1999/xlink",
-}
 
 MEDIA_CONTENT_TYPE = "glencoe play-in-place height-250 width-310"
 

--- a/tests/test_fig.py
+++ b/tests/test_fig.py
@@ -1,0 +1,950 @@
+import os
+import unittest
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+from elifetools import xmlio
+from elifecleaner import configure_logging, fig, LOGGER
+from tests.helpers import delete_files_in_folder, read_log_file_lines
+
+
+class TestInfFileIdentifier(unittest.TestCase):
+    "tests for fig.inf_file_identifier()"
+
+    def test_inf_file_identifer(self):
+        "identifier portion of an inline-graphic file name"
+        inf_file_name = "elife-70493-inf1.png"
+        expected = "inf1"
+        self.assertEqual(fig.inf_file_identifier(inf_file_name), expected)
+
+
+class TestFigFileNameIdentifer(unittest.TestCase):
+    "tests for fig.fig_file_name_identifier()"
+
+    def test_fig_file_name_identifier(self):
+        "generate a fig graphic id value"
+        sub_article_id = "sa2"
+        fig_index = "1"
+        expected = "sa2-fig1"
+        self.assertEqual(
+            fig.fig_file_name_identifier(sub_article_id, fig_index), expected
+        )
+
+
+class TestFigFileName(unittest.TestCase):
+    "tests for fig.fig_file_name()"
+
+    def test_fig_file_name(self):
+        "generate a fig graphic file name from an inline-graphic file name"
+        inf_file_name = "elife-70493-inf1.png"
+        sub_article_id = "sa2"
+        fig_index = "1"
+        expected = "elife-70493-sa2-fig1.png"
+        self.assertEqual(
+            fig.fig_file_name(inf_file_name, sub_article_id, fig_index),
+            expected,
+        )
+
+
+class TestMatchFigLabelContent(unittest.TestCase):
+    "tests for fig.match_fig_label_content()"
+
+    def test_match_fig_label_content(self):
+        "test matching paragraph content as a fig label"
+        cases = [
+            (None, False),
+            ("", False),
+            ("Test", False),
+            ("Review image 1.", True),
+            ("Review image 1", True),
+            ("Review table 1.", False),
+            ("Author response image 1.", True),
+        ]
+        for content, expected in cases:
+            self.assertEqual(fig.match_fig_label_content(content), expected)
+
+
+class TestIsPLabel(unittest.TestCase):
+    "tests for fig.is_p_label()"
+
+    def test_is_p_label(self):
+        "example of a matched label in a p tag"
+        xml_string = "<p><bold>Review image 1.</bold></p>"
+        expected = True
+        self.assertEqual(
+            fig.is_p_label(ElementTree.fromstring(xml_string), None, None, None),
+            expected,
+        )
+
+    def test_false(self):
+        "not a label in a p tag"
+        xml_string = "<p>Foo.</p>"
+        expected = False
+        self.assertEqual(
+            fig.is_p_label(ElementTree.fromstring(xml_string), None, None, None),
+            expected,
+        )
+
+
+class TestIsPInlineGraphic(unittest.TestCase):
+    "tests for fig.is_p_inline_graphic()"
+
+    def test_is_p_inline_graphic(self):
+        "simple example of an inline-graphic p tag"
+        xml_string = "<p><inline-graphic /></p>"
+        expected = True
+        self.assertEqual(
+            fig.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+    def test_whitespace(self):
+        "test if when whitespace surrounds the inline-graphic tag"
+        xml_string = "<p>   <inline-graphic />      </p>"
+        expected = True
+        self.assertEqual(
+            fig.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+    def test_false(self):
+        "not an inline-graphic p tag"
+        xml_string = "<p>Foo.</p>"
+        expected = False
+        self.assertEqual(
+            fig.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+    def test_none(self):
+        "an inline-graphic tag and other content returns None"
+        xml_string = "<p>An <inline-graphic/></p>"
+        expected = None
+        self.assertEqual(
+            fig.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+
+class TestFigTagIndexGroups(unittest.TestCase):
+    "tests for fig.fig_tag_index_groups()"
+
+    def test_fig_tag_index_groups(self):
+        "test finding a group of p tags to be converted to a fig"
+        xml_string = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Review image 1.</bold></p>"
+            b"<p>This is the caption for this image that describes what it contains.</p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf1.png" /> </p>'
+            b"<p>Another paragraph with an inline graphic "
+            b'<inline-graphic xlink:href="elife-70493-inf2.jpg" /></p>'
+            b"</body>"
+        )
+        expected = [{"label_index": 1, "caption_index": 2, "inline_graphic_index": 3}]
+        result = fig.fig_tag_index_groups(
+            ElementTree.fromstring(xml_string), None, None
+        )
+        self.assertEqual(len(result), 1)
+        self.assertDictEqual(result[0], expected[0])
+
+    def test_multiple_figs(self):
+        "test multiple groups of p tags to be converted to fig tags"
+        xml_string = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Review image 1.</bold></p>"
+            b"<p>This is the caption for this image that describes what it contains.</p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf1.png" /> </p>'
+            b"<p><bold>Review image 2</bold></p>"
+            b'<p><inline-graphic xlink:href="elife-70493-inf2.jpg" /></p>'
+            b"</body>"
+        )
+        expected = [
+            {"label_index": 1, "caption_index": 2, "inline_graphic_index": 3},
+            {"label_index": 4, "caption_index": False, "inline_graphic_index": 5},
+        ]
+        result = fig.fig_tag_index_groups(
+            ElementTree.fromstring(xml_string), None, None
+        )
+        self.assertEqual(len(result), 2)
+        # first fig
+        self.assertDictEqual(result[0], expected[0])
+        # second fig
+        self.assertDictEqual(result[1], expected[1])
+
+    def test_empty(self):
+        "test if no p tag groups are found"
+        xml_string = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<p>First paragraph.</p>"
+            b"</body>"
+        )
+        result = fig.fig_tag_index_groups(
+            ElementTree.fromstring(xml_string), None, None
+        )
+        self.assertEqual(len(result), 0)
+
+    def test_none(self):
+        "test None as input to finding p tag groups"
+        result = fig.fig_tag_index_groups(None, None, None)
+        self.assertEqual(result, [])
+
+
+class TestTransformFigGroups(unittest.TestCase):
+    "tests for fig.transform_fig_groups()"
+
+    def test_transform_fig_groups(self):
+        "give body tag and indexes of p tags to transform to a fig tag"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        xml_string = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Review image 1.</bold></p>"
+            b"<p>This is the caption for this image that describes what it contains.</p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf1.png" /> </p>'
+            b"<p><bold>Review image 2</bold></p>"
+            b'<p><inline-graphic xlink:href="elife-70493-inf2.jpg" /></p>'
+            b"</body>"
+        )
+        body_tag = ElementTree.fromstring(xml_string)
+        fig_index_groups = [
+            {"label_index": 1, "caption_index": 2, "inline_graphic_index": 3},
+            {"label_index": 4, "caption_index": False, "inline_graphic_index": 5},
+        ]
+        sub_article_id = "sa1"
+        expected = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<p>First paragraph.</p>"
+            b'<fig id="sa1fig1">'
+            b"<label>Review image 1.</label>"
+            b"<caption>"
+            b"<title>"
+            b"This is the caption for this image that describes what it contains."
+            b"</title>"
+            b"</caption>"
+            b'<graphic mimetype="image" mime-subtype="png" xlink:href="elife-70493-sa1-fig1.png" />'
+            b"</fig>"
+            b'<fig id="sa1fig2">'
+            b"<label>Review image 2</label>"
+            b'<graphic mimetype="image" mime-subtype="jpg" xlink:href="elife-70493-sa1-fig2.jpg" />'
+            b"</fig>"
+            b"</body>"
+        )
+        fig.transform_fig_groups(body_tag, fig_index_groups, sub_article_id)
+        self.assertEqual(ElementTree.tostring(body_tag), expected)
+
+
+class TestStripTagText(unittest.TestCase):
+    "tests for fig.strip_tag_text()"
+
+    def test_strip_tag_text(self):
+        "test an example with whitespace to the left of the tag"
+        xml_string = b"<p> <inline-graphic /> </p>"
+        expected = b"<p><inline-graphic /> </p>"
+        p_tag = ElementTree.fromstring(xml_string)
+        fig.strip_tag_text(p_tag)
+        self.assertEqual(ElementTree.tostring(p_tag), expected)
+
+    def test_non_element(self):
+        "test if the input is not a tag"
+        tag = "foo"
+        self.assertEqual(fig.strip_tag_text(tag), None)
+
+
+class TestStripTagTail(unittest.TestCase):
+    "tests for fig.strip_tag_tail()"
+
+    def test_strip_tag_tail(self):
+        "test an example with whitespace to the left and right of the tag"
+        xml_string = b"<p> <inline-graphic /> </p>"
+        expected = b"<inline-graphic />"
+        p_tag = ElementTree.fromstring(xml_string)
+        inline_graphic_tag = p_tag.find("inline-graphic")
+        fig.strip_tag_tail(inline_graphic_tag)
+        self.assertEqual(ElementTree.tostring(inline_graphic_tag), expected)
+
+    def test_non_element(self):
+        "test if the input is not a tag"
+        tag = "foo"
+        self.assertEqual(fig.strip_tag_tail(tag), None)
+
+
+class TestRemoveTagAttributes(unittest.TestCase):
+    "tests for fig.remove_tag_attributes()"
+
+    def test_remove_tag_attributes(self):
+        "test cleaning attributes from a p tag"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        xml_string = (
+            b'<p xmlns:xlink="http://www.w3.org/1999/xlink" id="p" xlink:href="foo" />'
+        )
+        tag = ElementTree.fromstring(xml_string)
+        expected = b"<p />"
+        fig.remove_tag_attributes(tag)
+        self.assertEqual(ElementTree.tostring(tag), expected)
+
+    def test_non_element(self):
+        "test if the input is not a tag"
+        tag = "foo"
+        self.assertEqual(fig.remove_tag_attributes(tag), None)
+
+
+class TestInlineGraphicTagFromTag(unittest.TestCase):
+    "tests for fig.inline_graphic_tag_from_tag()"
+
+    def test_tag_found(self):
+        "test getting a inline-graphic tag from a p tag"
+        xml_string = b"<p>   <inline-graphic />   </p>"
+        tag = ElementTree.fromstring(xml_string)
+        expected = b"<inline-graphic />"
+        result = fig.inline_graphic_tag_from_tag(tag)
+        self.assertEqual(ElementTree.tostring(result), expected)
+
+
+class TestInlineGraphicHrefs(unittest.TestCase):
+    "tests for fig.inline_graphic_hrefs()"
+
+    def test_inline_graphic_hrefs(self):
+        "get a list of xlink:href values from inline-graphic tags to be converted to fig"
+        xml_string = (
+            b'<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<body>"
+            b"<p><bold>Review image 1.</bold></p>"
+            b'<p><inline-graphic xlink:href="elife-70493-inf1.png"/></p>'
+            b"<p>Next paragraph is not an inline-graphic href.</p>"
+            b'<p><inline-graphic xlink:href="elife-70493-inf2.png"/></p>'
+            b"</body>"
+            b"</sub-article>"
+        )
+        identifier = "test.zip"
+        tag = ElementTree.fromstring(xml_string)
+        expected = ["elife-70493-inf1.png"]
+        result = fig.inline_graphic_hrefs(tag, identifier)
+        self.assertEqual(result, expected)
+
+
+class TestGraphicHrefs(unittest.TestCase):
+    "tests for fig.graphic_hrefs()"
+
+    def test_graphic_hrefs(self):
+        "get a list of xlink:href values from graphic tags"
+        xml_string = (
+            b'<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink"><body>'
+            b"<p>"
+            b'<fig id="sa1fig1">'
+            b"<label>Review image 1.</label>"
+            b"<caption>"
+            b"<title>A title.</title>"
+            b"<p>A caption.</p>"
+            b"</caption>"
+            b'<graphic mimetype="image" mime-subtype="png" xlink:href="elife-70493-sa1-fig1.png" />'
+            b"</fig>"
+            b"</p>"
+            b"</body></sub-article>"
+        )
+        identifier = "test.zip"
+        tag = ElementTree.fromstring(xml_string)
+        expected = ["elife-70493-sa1-fig1.png"]
+        result = fig.graphic_hrefs(tag, identifier)
+        self.assertEqual(result, expected)
+
+    def test_graphic_hrefs_no_match(self):
+        "empty list of xlink:href values when there is no graphic tag"
+        xml_string = (
+            b'<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<body><p/></body>"
+            b"</sub-article>"
+        )
+        identifier = "test.zip"
+        tag = ElementTree.fromstring(xml_string)
+        expected = []
+        result = fig.graphic_hrefs(tag, identifier)
+        self.assertEqual(result, expected)
+
+
+class TestSetLabelTag(unittest.TestCase):
+    "tests for fig.set_label_tag()"
+
+    def test_set_label_tag(self):
+        "create label tag for a fig"
+        body_tag_xml_string = b"<body><p><bold>Label</bold></p></body>"
+        body_tag = ElementTree.fromstring(body_tag_xml_string)
+        tag = Element("fig")
+        label_index = 0
+        expected = b"<fig><label>Label</label></fig>"
+        fig.set_label_tag(tag, body_tag, label_index)
+        self.assertEqual(ElementTree.tostring(tag), expected)
+
+
+class TestSplitTtitleParts(unittest.TestCase):
+    "tests for fig.split_title_parts()"
+
+    def test_split_title_parts(self):
+        "test spliting a simple example"
+        xml_string = "<p>A title. A caption paragraph.</p>"
+        expected = ["<p>A title.", " A caption paragraph.", "</p>"]
+        result = fig.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_multiple_sentences(self):
+        "test spliting a simple example"
+        xml_string = "<p>A title. A caption paragraph. Another paragraph.</p>"
+        expected = [
+            "<p>A title.",
+            " A caption paragraph.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        result = fig.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_namespace(self):
+        "test spliting a simple example"
+        xml_string = (
+            '<p xmlns:xlink="http://www.w3.org/1999/xlink">'
+            'A title only (<ext-link xlink:href="http://example.org"/>).'
+            "</p>"
+        )
+        expected = [
+            '<p xmlns:xlink="http://www.w3.org/1999/xlink">A title only (<ext-link '
+            'xlink:href="http://example.org"/>).',
+            "</p>",
+        ]
+        result = fig.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_unmatched_tags(self):
+        "example where there are unmatched tags in the result"
+        xml_string = xml_string = (
+            "<p>The title<bold>.</bold> Another <bold>bold term</bold>."
+            " Another paragraph.</p>"
+        )
+        expected = [
+            "<p>The title<bold>.",
+            "</bold> Another <bold>bold term</bold>.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        result = fig.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_blank_string(self):
+        "test splitting a blank string"
+        xml_string = ""
+        expected = []
+        result = fig.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+
+class TestTitleParagraphContent(unittest.TestCase):
+    "tests for fig.title_paragraph_content()"
+
+    def test_title_paragraph_content(self):
+        "a simple example of string parts"
+        string_list = [
+            "<p>Caption title.",
+            " Caption paragraph.",
+            "</p>",
+        ]
+        expected = ("<p>Caption title.", " Caption paragraph.</p>")
+        result = fig.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+    def test_multiple_sentences(self):
+        "a simple example of string parts"
+        string_list = [
+            "<p>A title.",
+            " A caption paragraph.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        expected = ("<p>A title.", " A caption paragraph. Another paragraph.</p>")
+        result = fig.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+    def test_italic(self):
+        "test where an unmatched inline formatting tag is repaired"
+        string_list = [
+            "<p>The title<bold>.",
+            "</bold> Another <bold>bold term</bold>.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        expected = (
+            "<p>The title<bold>.</bold> Another <bold>bold term</bold>.",
+            " Another paragraph.</p>",
+        )
+        result = fig.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+    def test_empty_list(self):
+        "test an empty list"
+        string_list = [""]
+        expected = ("", None)
+        result = fig.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+
+class TestCaptionTitleParagraph(unittest.TestCase):
+    "tests for fig.caption_title_paragraph()"
+
+    def test_simple_title(self):
+        "test a simple example"
+        xml_string = "<p>Title. Caption.</p>"
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
+        self.assertEqual(ElementTree.tostring(caption_title_p_tag), b"<p>Title.</p>")
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Caption.</p>"
+        )
+
+    def test_organism_title(self):
+        "test for italic tag included"
+        xml_string = "<p>In <italic>B. subtilis</italic>, the title. Caption.</p>"
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b"<p>In <italic>B. subtilis</italic>, the title.</p>",
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Caption.</p>"
+        )
+
+    def test_two_bold_tags(self):
+        "edge case with more than one bold tag and second one is around the title full stop"
+        xml_string = (
+            "<p>The title<bold>.</bold> Another <bold>bold term</bold>."
+            " Another paragraph.</p>"
+        )
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b"<p>The title<bold>.</bold> Another <bold>bold term</bold>.</p>",
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Another paragraph.</p>"
+        )
+
+    def test_ext_link_tag(self):
+        "edge case with an ext-link tag in the title and challenging full stop separations"
+        xml_string = '<p xmlns:xlink="http://www.w3.org/1999/xlink">(Figure 2A from <ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>)<bold>.</bold> Comparison of Tests against Γ ( 4,5) (a = 0.05). The normality tests used were severely underpowered for n&lt;100 (<ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>).</p>'
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b'<p xmlns:xlink="http://www.w3.org/1999/xlink">(Figure 2A from <ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>)<bold>.</bold> Comparison of Tests against &#915; ( 4,5) (a = 0.</p>',
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag),
+            b'<p xmlns:xlink="http://www.w3.org/1999/xlink">05). The normality tests used were severely underpowered for n&lt;100 (<ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>).</p>',
+        )
+
+    def test_mml_tag(self):
+        "edge case where a full stop in math formula should not be used as separate parts"
+        xml_string = '<p xmlns:mml="http://www.w3.org/1998/Math/MathML">For one participant <inline-formula><mml:math alttext="" display="inline"><mml:mspace width="0.222em" /></mml:math></inline-formula> is a formula.</p>'
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b'<p xmlns:mml="http://www.w3.org/1998/Math/MathML">For one participant <inline-formula><mml:math alttext="" display="inline"><mml:mspace width="0.222em" /></mml:math></inline-formula> is a formula.</p>',
+        )
+        self.assertEqual(ElementTree.tostring(caption_paragraph_p_tag), b"<p />")
+
+
+class TestSetCaptionTag(unittest.TestCase):
+    "tests for fig.set_caption_tag()"
+
+    def test_set_caption_tag(self):
+        "create caption tag for a fig"
+        body_tag_xml_string = (
+            b"<body>"
+            b"<p>Title <italic>here</italic>. "
+            b"Caption paragraph <italic>ici</italic>."
+            b"</p>"
+            b"</body>"
+        )
+        body_tag = ElementTree.fromstring(body_tag_xml_string)
+        tag = Element("fig")
+        caption_index = 0
+        expected = (
+            b"<fig>"
+            b"<caption>"
+            b"<title>Title <italic>here</italic>.</title>"
+            b"<p>Caption paragraph <italic>ici</italic>.</p>"
+            b"</caption>"
+            b"</fig>"
+        )
+        fig.set_caption_tag(tag, body_tag, caption_index)
+        self.assertEqual(ElementTree.tostring(tag), expected)
+
+
+class TestSetGraphicTag(unittest.TestCase):
+    "tests for fig.set_graphic_tag()"
+
+    def test_set_graphic_tag(self):
+        "create graphic tag for a fig"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        xml_string = '<fig xmlns:xlink="http://www.w3.org/1999/xlink" />'
+        tag = ElementTree.fromstring(xml_string)
+        image_href = "image.png"
+        new_file_name = "new_image.png"
+        expected = (
+            b'<fig xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b'<graphic mimetype="image" mime-subtype="png" xlink:href="new_image.png" />'
+            b"</fig>"
+        )
+        fig.set_graphic_tag(tag, image_href, new_file_name)
+        self.assertEqual(ElementTree.tostring(tag), expected)
+
+
+class TestTransformFigGroup(unittest.TestCase):
+    "tests for fig.transform_fig_group()"
+
+    def test_transform_fig_group(self):
+        "give body tag and indexes of p tags to transform to a fig tag"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        xml_string = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Review image 1.</bold></p>"
+            b"<p>This is the caption for this image that describes what it contains.</p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf1.png" /> </p>'
+            b"</body>"
+        )
+        body_tag = ElementTree.fromstring(xml_string)
+        fig_index = 1
+        fig_group = {"label_index": 1, "caption_index": 2, "inline_graphic_index": 3}
+        sub_article_id = "sa1"
+        expected = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<p>First paragraph.</p>"
+            b'<fig id="sa1fig1">'
+            b"<label>Review image 1.</label>"
+            b"<caption>"
+            b"<title>"
+            b"This is the caption for this image that describes what it contains."
+            b"</title>"
+            b"</caption>"
+            b'<graphic mimetype="image" mime-subtype="png" xlink:href="elife-70493-sa1-fig1.png" />'
+            b"</fig>"
+            b"</body>"
+        )
+
+        fig.transform_fig_group(body_tag, fig_index, fig_group, sub_article_id)
+        self.assertEqual(ElementTree.tostring(body_tag), expected)
+
+
+def sub_article_xml_fixture(
+    article_type, sub_article_id, front_stub_xml_string, body_xml_string
+):
+    "generate test fixture XML for a sub-article"
+    return (
+        b'<sub-article xmlns:xlink="http://www.w3.org/1999/xlink" '
+        b'article-type="%s" id="%s">%s%s</sub-article>'
+        % (article_type, sub_article_id, front_stub_xml_string, body_xml_string)
+    )
+
+
+def sa1_sub_article_xml_fixture():
+    "generate XML test fixture for a referee-report"
+    article_type = b"referee-report"
+    sub_article_id = b"sa1"
+    front_stub_xml_string = (
+        b"<front-stub>"
+        b'<article-id pub-id-type="doi">10.7554/eLife.79713.1.sa1</article-id>'
+        b"<title-group>"
+        b"<article-title>Reviewer #1 (Public Review):</article-title>"
+        b"</title-group>"
+        b"</front-stub>"
+    )
+    body_xml_string = (
+        b"<body>"
+        b"<p>First paragraph.</p>"
+        b"<p><bold>Review image 1.</bold></p>"
+        b"<p>This is the caption for this image that describes what it contains.</p>"
+        b'<p> <inline-graphic xlink:href="elife-70493-inf1.png" /> </p>'
+        b"<p>Another paragraph with an inline graphic "
+        b'<inline-graphic xlink:href="elife-70493-inf2.jpg" /></p>'
+        b"</body>"
+    )
+    return sub_article_xml_fixture(
+        article_type, sub_article_id, front_stub_xml_string, body_xml_string
+    )
+
+
+def sa4_sub_article_xml_fixture(body_xml_string):
+    "generate XML test fixture for an author-comment"
+    article_type = b"author-comment"
+    sub_article_id = b"sa4"
+    front_stub_xml_string = (
+        b"<front-stub>"
+        b'<article-id pub-id-type="doi">10.7554/eLife.79713.1.sa4</article-id>'
+        b"<title-group><article-title>Author response</article-title></title-group>"
+        b"</front-stub>"
+    )
+    return sub_article_xml_fixture(
+        article_type, sub_article_id, front_stub_xml_string, body_xml_string
+    )
+
+
+class TestTransformFig(unittest.TestCase):
+    "tests for fig.transform_fig()"
+
+    def setUp(self):
+        self.identifier = "test.zip"
+        self.temp_dir = "tests/tmp"
+        self.log_file = os.path.join(self.temp_dir, "test.log")
+        self.log_handler = configure_logging(self.log_file)
+
+    def tearDown(self):
+        LOGGER.removeHandler(self.log_handler)
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_referee_report(self):
+        "convert tags to a fig in a referee-report fixture"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        xml_string = sa1_sub_article_xml_fixture()
+        sub_article_root = ElementTree.fromstring(xml_string)
+        root = fig.transform_fig(sub_article_root, self.identifier)
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertTrue("<p>First paragraph.</p>" in rough_xml_string.decode("utf8"))
+        self.assertTrue(
+            '<inline-graphic xlink:href="elife-70493-inf2.jpg" />'
+            in rough_xml_string.decode("utf8")
+        )
+        print(rough_xml_string.decode("utf8"))
+        self.assertTrue(
+            (
+                "<body>"
+                "<p>First paragraph.</p>"
+                '<fig id="sa1fig1">'
+                "<label>Review image 1.</label>"
+                "<caption>"
+                "<title>"
+                "This is the caption for this image that describes what it contains."
+                "</title>"
+                "</caption>"
+                '<graphic mimetype="image" mime-subtype="png" '
+                'xlink:href="elife-70493-sa1-fig1.png" />'
+                "</fig>"
+                "<p>Another paragraph with an inline graphic "
+                '<inline-graphic xlink:href="elife-70493-inf2.jpg" />'
+                "</p>"
+                "</body>"
+            )
+            in rough_xml_string.decode("utf8")
+        )
+        info_prefix = "INFO elifecleaner:fig"
+        expected = [
+            '%s:%s: %s potential label "Review image 1." in p tag 1 of id sa1\n'
+            % (info_prefix, "is_p_label", self.identifier),
+            "%s:%s: %s label p tag index 1 of id sa1\n"
+            % (info_prefix, "fig_tag_index_groups", self.identifier),
+            "%s:%s: %s no inline-graphic tag found in p tag 2 of id sa1\n"
+            % (info_prefix, "is_p_inline_graphic", self.identifier),
+            "%s:%s: %s only inline-graphic tag found in p tag 3 of id sa1\n"
+            % (info_prefix, "is_p_inline_graphic", self.identifier),
+        ]
+        self.assertEqual(read_log_file_lines(self.log_file), expected)
+
+    def test_author_response(self):
+        "convert tags to a fig in an author-comment fixture"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        body_xml_string = (
+            b"<body>"
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Author response image 1.</bold></p>"
+            b"<p>This is the caption for this image that describes what it contains.</p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf3.png" /> </p>'
+            b"<p>Another paragraph with an inline graphic "
+            b'<inline-graphic xlink:href="elife-70493-inf4.jpg" /></p>'
+            b"</body>"
+        )
+        xml_string = sa4_sub_article_xml_fixture(body_xml_string)
+
+        sub_article_root = ElementTree.fromstring(xml_string)
+        root = fig.transform_fig(sub_article_root, self.identifier)
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertTrue("<p>First paragraph.</p>" in rough_xml_string.decode("utf8"))
+        self.assertTrue(
+            '<inline-graphic xlink:href="elife-70493-inf4.jpg" />'
+            in rough_xml_string.decode("utf8")
+        )
+        self.assertTrue(
+            (
+                "<body>"
+                "<p>First paragraph.</p>"
+                '<fig id="sa4fig1">'
+                "<label>Author response image 1.</label>"
+                "<caption>"
+                "<title>"
+                "This is the caption for this image that describes what it contains."
+                "</title>"
+                "</caption>"
+                '<graphic mimetype="image" mime-subtype="png" '
+                'xlink:href="elife-70493-sa4-fig1.png" />'
+                "</fig>"
+                "<p>Another paragraph with an inline graphic "
+                '<inline-graphic xlink:href="elife-70493-inf4.jpg" />'
+                "</p>"
+                "</body>"
+            )
+            in rough_xml_string.decode("utf8")
+        )
+        # self.assertTrue(False)
+        info_prefix = "INFO elifecleaner:fig"
+        expected = [
+            '%s:%s: %s potential label "Author response image 1." in p tag 1 of id sa4\n'
+            % (info_prefix, "is_p_label", self.identifier),
+            "%s:%s: %s label p tag index 1 of id sa4\n"
+            % (info_prefix, "fig_tag_index_groups", self.identifier),
+            "%s:%s: %s no inline-graphic tag found in p tag 2 of id sa4\n"
+            % (info_prefix, "is_p_inline_graphic", self.identifier),
+            "%s:%s: %s only inline-graphic tag found in p tag 3 of id sa4\n"
+            % (info_prefix, "is_p_inline_graphic", self.identifier),
+        ]
+        self.assertEqual(read_log_file_lines(self.log_file), expected)
+
+    def test_caption_italic(self):
+        "convert tags to a fig where the caption has an inline intalic tag"
+        # register XML namespaces
+        xmlio.register_xmlns()
+
+        body_xml_string = (
+            b"<body>"
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Author response image 1.</bold></p>"
+            b'<p>Caption with an <italic id="foo">italic</italic> tag or '
+            b"<bold>bold</bold> too.</p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf3.png" /> </p>'
+            b"<p>Another paragraph with an inline graphic "
+            b'<inline-graphic xlink:href="elife-70493-inf4.jpg" /></p>'
+            b"</body>"
+        )
+
+        xml_string = sa4_sub_article_xml_fixture(body_xml_string)
+        sub_article_root = ElementTree.fromstring(xml_string)
+        root = fig.transform_fig(sub_article_root, self.identifier)
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertTrue(
+            (
+                "<body>"
+                "<p>First paragraph.</p>"
+                '<fig id="sa4fig1">'
+                "<label>Author response image 1.</label>"
+                "<caption>"
+                "<title>"
+                'Caption with an <italic id="foo">italic</italic> tag or <bold>bold</bold> too.'
+                "</title>"
+                "</caption>"
+                '<graphic mimetype="image" mime-subtype="png" '
+                'xlink:href="elife-70493-sa4-fig1.png" />'
+                "</fig>"
+                "<p>Another paragraph with an inline graphic "
+                '<inline-graphic xlink:href="elife-70493-inf4.jpg" />'
+                "</p>"
+                "</body>"
+            )
+            in rough_xml_string.decode("utf8")
+        )
+
+    def test_no_caption(self):
+        "convert tags to a fig where there is no p tag for the caption content"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        body_xml_string = (
+            b"<body>"
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Author response image 1.</bold></p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf3.png" /> </p>'
+            b"<p>Another paragraph with an inline graphic "
+            b'<inline-graphic xlink:href="elife-70493-inf4.jpg" /></p>'
+            b"</body>"
+        )
+        xml_string = sa4_sub_article_xml_fixture(body_xml_string)
+
+        sub_article_root = ElementTree.fromstring(xml_string)
+        root = fig.transform_fig(sub_article_root, self.identifier)
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertTrue(
+            (
+                "<body>"
+                "<p>First paragraph.</p>"
+                '<fig id="sa4fig1">'
+                "<label>Author response image 1.</label>"
+                '<graphic mimetype="image" mime-subtype="png" '
+                'xlink:href="elife-70493-sa4-fig1.png" />'
+                "</fig>"
+                "<p>Another paragraph with an inline graphic "
+                '<inline-graphic xlink:href="elife-70493-inf4.jpg" />'
+                "</p>"
+                "</body>"
+            )
+            in rough_xml_string.decode("utf8")
+        )
+
+    def test_multiple_caption(self):
+        "test if there are multiple caption p tags before the inline-graphic tag"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        body_xml_string = (
+            b"<body>"
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Author response image 1.</bold></p>"
+            b"<p>Caption paragraph one.</p>"
+            b"<p>Caption paragraph two.</p>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf3.png" /> </p>'
+            b"<p>Another paragraph with an inline graphic "
+            b'<inline-graphic xlink:href="elife-70493-inf4.jpg" /></p>'
+            b"</body>"
+        )
+        xml_string = sa4_sub_article_xml_fixture(body_xml_string)
+
+        sub_article_root = ElementTree.fromstring(xml_string)
+        root = fig.transform_fig(sub_article_root, self.identifier)
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertEqual(xml_string, rough_xml_string)
+
+    def test_non_p_tag(self):
+        "test if the p tag order is disrupted with a sec tag"
+        # register XML namespaces
+        xmlio.register_xmlns()
+
+        body_xml_string = (
+            b"<body>"
+            b"<p>First paragraph.</p>"
+            b"<p><bold>Author response image 1.</bold></p>"
+            b"<sec>Non-p tag</sec>"
+            b'<p> <inline-graphic xlink:href="elife-70493-inf3.png" /> </p>'
+            b"<p>Another paragraph with an inline graphic "
+            b'<inline-graphic xlink:href="elife-70493-inf4.jpg" /></p>'
+            b"</body>"
+        )
+        xml_string = sa4_sub_article_xml_fixture(body_xml_string)
+
+        sub_article_root = ElementTree.fromstring(xml_string)
+        root = fig.transform_fig(sub_article_root, self.identifier)
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertEqual(xml_string, rough_xml_string)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from xml.etree import ElementTree
 from elifecleaner import utils
 
 
@@ -6,6 +7,16 @@ class TestPadMsid(unittest.TestCase):
     def test_pad_msid(self):
         self.assertEqual(utils.pad_msid(666), "00666")
         self.assertEqual(utils.pad_msid("666"), "00666")
+
+
+class TestFileExtension(unittest.TestCase):
+    def test_file_extension(self):
+        passes = [(None, None), ("elife-70493-sa1-fig1.png", "png")]
+        for file_name, expected in passes:
+            self.assertEqual(
+                utils.file_extension(file_name),
+                expected,
+            )
 
 
 class TestMatchControlCharacterEntities(unittest.TestCase):
@@ -42,3 +53,26 @@ class TestReplaceControlCharacterEntities(unittest.TestCase):
         string = string_base % "&#x001D;"
         expected = string_base % utils.CONTROL_CHARACTER_ENTITY_REPLACEMENT
         self.assertEqual(expected, utils.replace_control_character_entities(string))
+
+
+class TestXlinkHref(unittest.TestCase):
+    def test_xlink_href(self):
+        image_href = "image.png"
+        xml_string = (
+            '<inline-graphic xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="%s"/>'
+        ) % image_href
+        href = utils.xlink_href(ElementTree.fromstring(xml_string))
+        self.assertEqual(href, image_href)
+
+
+class TestOpenTag(unittest.TestCase):
+    def test_open_tag(self):
+        tag_name = "italic"
+        expected = "<italic>"
+        self.assertEqual(utils.open_tag(tag_name), expected)
+
+    def test_open_tag_with_attr(self):
+        tag_name = "xref"
+        attr = {"id": "sa2fig1", "ref-type": "fig"}
+        expected = '<xref id="sa2fig1" ref-type="fig">'
+        self.assertEqual(utils.open_tag(tag_name, attr), expected)


### PR DESCRIPTION
Adding a new module `elifecleaner.fig` which includes logic to convert `<inline-graphic>` and related `<p>` tags into a `<fig>` tag including a `<caption>` and `<graphic>` tag.

Re issue https://github.com/elifesciences/issues/issues/7754