### PR TITLE
Ordered lists into paragraphs in sub-article.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.38.0"
+__version__ = "0.39.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docmaptools==0.6.0
+docmaptools==0.9.0
 elifetools==0.32.0
 elifearticle==0.14.0
 jatsgenerator==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=["elifecleaner"],
     license="MIT",
     install_requires=[
-        "docmaptools>=0.6.0",
+        "docmaptools>=0.9.0",
         "elifetools",
         "elifearticle>=0.10.0",
         "jatsgenerator>=0.4.0",


### PR DESCRIPTION
When formatting the content JSON of sub-article content, convert ordered lists into paragraphs.

Re issue https://github.com/elifesciences/issues/issues/8310