### PR TITLE
assoc_ed type editor used as peer review editor.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.40.0"
+__version__ = "0.41.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -96,7 +96,7 @@ def sub_article_doi(article_doi, index):
     return "%s.%s" % (article_doi, sub_article_id(index))
 
 
-EDITOR_REPORT_CONTRIB_TYPES = ["editor"]
+EDITOR_REPORT_CONTRIB_TYPES = ["assoc_ed"]
 
 
 def sub_article_contributors(article_object, sub_article_object):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "docmaptools>=0.9.0",
         "elifetools",
-        "elifearticle>=0.10.0",
+        "elifearticle>=0.15.0",
         "jatsgenerator>=0.4.0",
         "PyYAML>=5.4.1",
         "wand >= 0.5.2",

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -292,7 +292,7 @@ class TestSubArticleContributors(unittest.TestCase):
         author.orcid = "https://orcid.org/0000-0000-0000-0000"
         author.orcid_authenticated = True
         self.article_object.contributors.append(author)
-        editor = Contributor("editor", "Itor", "Ed")
+        editor = Contributor("assoc_ed", "Itor", "Ed")
         self.article_object.editors.append(editor)
         # reviewer contrib_type will not be added to an editor-report
         reviewer = Contributor("reviewer", "Ewer", "Revi")
@@ -504,7 +504,7 @@ class TestFormatContentJson(unittest.TestCase):
         ]
         article = Article("10.7554/eLife.79713.1")
         article.contributors = [Contributor("author", "Surname", "Given")]
-        article.editors = [Contributor("editor", "Editor", "Given")]
+        article.editors = [Contributor("assoc_ed", "Editor", "Given")]
         # invoke
         sub_article_data = sub_article.format_content_json(CONTENT_JSON, article)
         # assertions


### PR DESCRIPTION
`elifearticle==0.15.0` will parse from the XML file contributor(s) of type `assoc_ed` as an `Article` editor, and this is the correct one to use when adding an author to the `eLife assessment` peer review `<sub-article>`.

Re issue https://github.com/elifesciences/issues/issues/8313