### PR TITLE
Review date and history tag enhancements.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-docmaptools==0.9.0
+docmaptools==0.12.0
 elifetools==0.32.0
 elifearticle==0.14.0
-jatsgenerator==0.5.0
+jatsgenerator==0.6.0
 mock==4.0.3
 pytest==6.2.2
 PyYAML==5.4.1

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
     packages=["elifecleaner"],
     license="MIT",
     install_requires=[
-        "docmaptools>=0.9.0",
+        "docmaptools>=0.12.0",
         "elifetools",
         "elifearticle>=0.15.0",
-        "jatsgenerator>=0.4.0",
+        "jatsgenerator>=0.6.0",
         "PyYAML>=5.4.1",
         "wand >= 0.5.2",
     ],


### PR DESCRIPTION
From a docmap, get the `under-review` date string. Convert it to a date struct object. Find or add a `<history>` tag to the XML, and add a `<date>` tag using the date struct.

Re issue https://github.com/elifesciences/issues/issues/7721