### PR TITLE
Remove duplicate kwd tags in transform XML.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/transform.py
+++ b/elifecleaner/transform.py
@@ -129,6 +129,7 @@ def transform_xml(xml_asset_path, identifier):
     root = parse.parse_article_xml(xml_asset_path)
     soup = parser.parse_document(xml_asset_path)
     root = transform_subject_tags(root, identifier)
+    root = transform_kwd_tags(root, identifier)
     root = transform_xml_history_tags(root, soup, identifier)
     root = transform_xml_funding(root, identifier)
     write_xml_file(root, xml_asset_path, identifier)
@@ -214,6 +215,21 @@ def transform_subject_tags(root, identifier):
                 )
                 article_categories_tag.remove(subject_group_tag)
             subject_set.add(subject_tag.text)
+    return root
+
+
+def transform_kwd_tags(root, identifier):
+    "remove duplicate kwd tags"
+    # for each kwd-group tag, look for and remove duplicate kwd tags
+    for kwd_group_tag in root.findall("front/article-meta/kwd-group"):
+        kwd_set = set()
+        for kwd_tag in kwd_group_tag.findall("kwd"):
+            if kwd_tag.text in kwd_set:
+                LOGGER.info(
+                    "%s removing duplicate kwd tag %s" % (identifier, kwd_tag.text)
+                )
+                kwd_group_tag.remove(kwd_tag)
+            kwd_set.add(kwd_tag.text)
     return root
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -365,6 +365,44 @@ class TestTransformSubjectTags(unittest.TestCase):
         self.assertEqual(ElementTree.tostring(root), expected)
 
 
+class TestTransformKwdTags(unittest.TestCase):
+    "tests for transform.transform_kwd_tags()"
+
+    def test_transform_kwd_tags(self):
+        "test removing duplicate kwd tags"
+        xml_string = (
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            '<kwd-group kwd-group-type="research-organism">'
+            "<title>Research organism</title>"
+            "<kwd>Human</kwd>"
+            "<kwd>Human</kwd>"
+            "<kwd>Other</kwd>"
+            "<kwd>Other</kwd>"
+            "</kwd-group>"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        expected = (
+            b"<article>"
+            b"<front>"
+            b"<article-meta>"
+            b'<kwd-group kwd-group-type="research-organism">'
+            b"<title>Research organism</title>"
+            b"<kwd>Human</kwd>"
+            b"<kwd>Other</kwd>"
+            b"</kwd-group>"
+            b"</article-meta>"
+            b"</front>"
+            b"</article>"
+        )
+        transform.transform_kwd_tags(root, None)
+        self.assertEqual(ElementTree.tostring(root), expected)
+
+
 class TestTransformXmlFileTags(unittest.TestCase):
     def test_transform_xml_file_tags(self):
         # populate an ElementTree


### PR DESCRIPTION
Function `transform_kwd_tags()` removes duplicate `<kwd>` tag values found in each `<kwd-group>` tag.