### PR TITLE
Parse date string which includes microseconds.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -277,7 +277,7 @@ def review_date_from_docmap(docmap_string, identifier=None):
 
 def date_struct_from_string(date_string):
     "parse the date_string into time.struct_time"
-    formats = ["%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"]
+    formats = ["%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"]
     for date_format in formats:
         try:
             return time.strptime(date_string, date_format)

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -630,7 +630,14 @@ class TestDateStructFromString(unittest.TestCase):
         self.assertEqual(result, expected)
         with open(self.log_file, "r") as open_file:
             log_messages = open_file.readlines()
-            self.assertEqual(log_messages, [])
+            self.assertEqual(
+                log_messages[-1],
+                (
+                    "INFO elifecleaner:prc:date_struct_from_string: "
+                    'unable to parse "%s" using format "%s"\n'
+                )
+                % (date_string, "%Y-%m-%dT%H:%M:%S.%f%z"),
+            )
 
     def test_date(self):
         "test docmap which has a review date"
@@ -649,6 +656,16 @@ class TestDateStructFromString(unittest.TestCase):
                 % (date_string, "%Y-%m-%dT%H:%M:%S%z"),
             )
 
+    def test_with_microtime(self):
+        "test docmap which has a review date"
+        date_string = "2022-11-28T11:30:05.579531+00:00"
+        expected = time.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%f%z")
+        result = prc.date_struct_from_string(date_string)
+        self.assertEqual(result, expected)
+        with open(self.log_file, "r") as open_file:
+            log_messages = open_file.readlines()
+            self.assertEqual(log_messages, [])
+
     def test_not_a_date(self):
         "test docmap which has a review date"
         date_string = "not_a_date"
@@ -663,7 +680,7 @@ class TestDateStructFromString(unittest.TestCase):
                     "INFO elifecleaner:prc:date_struct_from_string: "
                     'unable to parse "%s" using format "%s"\n'
                 )
-                % (date_string, "%Y-%m-%dT%H:%M:%S%z"),
+                % (date_string, "%Y-%m-%dT%H:%M:%S.%f%z"),
             )
 
 


### PR DESCRIPTION
In `prc.date_struct_from_string()`.