### PR TITLE
Add pub-history tag from docmap preprint data.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
New function `prc.add_pub_history()` to add a `<pub-history>` tag to the `<article-meta>`, and add `<event>` tags for each of the preprint data returned from a docmap.

Re issue https://github.com/elifesciences/issues/issues/7721