### PR TITLE
Event desc tags

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -372,6 +372,7 @@ def add_pub_history(root, history_data, identifier=None):
             if history_event_data.get("type"):
                 date_tag.set("date-type", history_event_data.get("type"))
             jats_build.set_dmy(date_tag, date_struct)
+            date_tag.set("iso-8601-date", time.strftime("%Y-%m-%d", date_struct))
             if history_event_data.get("doi"):
                 self_uri_tag = SubElement(event_tag, "self-uri")
                 if history_event_data.get("type"):

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -319,6 +319,11 @@ def add_history_date(root, date_type, date_struct, identifier=None):
     return root
 
 
+EVENT_DESC_PREPRINT = "This manuscript was published as a preprint."
+EVENT_DESC_REVIEWED_PREPRINT = "This manuscript was published as a reviewed preprint."
+EVENT_DESC_REVISED_PREPRINT = "The reviewed preprint was revised."
+
+
 def add_pub_history(root, history_data, identifier=None):
     "add the pub-history tag and add event data to it"
     if not history_data:
@@ -345,8 +350,22 @@ def add_pub_history(root, history_data, identifier=None):
         pub_history_tag = Element("pub-history")
         article_meta_tag.insert(insert_index, pub_history_tag)
     # add event tags to the pub-history tag
+    added_reviewed_preprint = None
     for history_event_data in history_data:
         event_tag = SubElement(pub_history_tag, "event")
+        if history_event_data.get("type"):
+            if history_event_data.get("type") == "preprint":
+                event_desc_tag = SubElement(event_tag, "event-desc")
+                event_desc_tag.text = EVENT_DESC_PREPRINT
+            elif history_event_data.get("type") == "reviewed-preprint":
+                event_desc_tag = SubElement(event_tag, "event-desc")
+                if added_reviewed_preprint:
+                    # already added one reviewed-preprint
+                    event_desc_tag.text = EVENT_DESC_REVISED_PREPRINT
+                else:
+                    # adding the first reviewed-preprint
+                    event_desc_tag.text = EVENT_DESC_REVIEWED_PREPRINT
+                added_reviewed_preprint = True
         if history_event_data.get("date"):
             date_struct = date_struct_from_string(history_event_data.get("date"))
             date_tag = SubElement(event_tag, "date")

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -800,6 +800,7 @@ class TestAddPubHistory(unittest.TestCase):
         self.xml_output = (
             "<pub-history>"
             "<event>"
+            "<event-desc>This manuscript was published as a preprint.</event-desc>"
             '<date date-type="preprint">'
             "<day>22</day>"
             "<month>11</month>"
@@ -810,6 +811,7 @@ class TestAddPubHistory(unittest.TestCase):
             "</self-uri>"
             "</event>"
             "<event>"
+            "<event-desc>This manuscript was published as a reviewed preprint.</event-desc>"
             '<date date-type="reviewed-preprint">'
             "<day>25</day>"
             "<month>01</month>"
@@ -820,6 +822,7 @@ class TestAddPubHistory(unittest.TestCase):
             "</self-uri>"
             "</event>"
             "<event>"
+            "<event-desc>The reviewed preprint was revised.</event-desc>"
             '<date date-type="reviewed-preprint">'
             "<day>10</day>"
             "<month>05</month>"

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -801,7 +801,7 @@ class TestAddPubHistory(unittest.TestCase):
             "<pub-history>"
             "<event>"
             "<event-desc>This manuscript was published as a preprint.</event-desc>"
-            '<date date-type="preprint">'
+            '<date date-type="preprint" iso-8601-date="2022-11-22">'
             "<day>22</day>"
             "<month>11</month>"
             "<year>2022</year>"
@@ -812,7 +812,7 @@ class TestAddPubHistory(unittest.TestCase):
             "</event>"
             "<event>"
             "<event-desc>This manuscript was published as a reviewed preprint.</event-desc>"
-            '<date date-type="reviewed-preprint">'
+            '<date date-type="reviewed-preprint" iso-8601-date="2023-01-25">'
             "<day>25</day>"
             "<month>01</month>"
             "<year>2023</year>"
@@ -823,7 +823,7 @@ class TestAddPubHistory(unittest.TestCase):
             "</event>"
             "<event>"
             "<event-desc>The reviewed preprint was revised.</event-desc>"
-            '<date date-type="reviewed-preprint">'
+            '<date date-type="reviewed-preprint" iso-8601-date="2023-05-10">'
             "<day>10</day>"
             "<month>05</month>"
             "<year>2023</year>"


### PR DESCRIPTION
Add `<event-desc>` tags to `<event>` tag in `<pub-history>`, using placeholder text as defined in constants.

Also add an `@iso-8601-date` attribute to the `<date>` tag.

Enhancement to PR https://github.com/elifesciences/elife-cleaner/pull/117

Re issue https://github.com/elifesciences/issues/issues/8416