### PR TITLE
self-uri xlink:href attribute instead of as text.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -377,5 +377,8 @@ def add_pub_history(root, history_data, identifier=None):
                 self_uri_tag = SubElement(event_tag, "self-uri")
                 if history_event_data.get("type"):
                     self_uri_tag.set("content-type", history_event_data.get("type"))
-                self_uri_tag.text = doi_to_doi_uri(history_event_data.get("doi"))
+                self_uri_tag.set(
+                    "{http://www.w3.org/1999/xlink}href",
+                    doi_to_doi_uri(history_event_data.get("doi")),
+                )
     return root


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8421, corrected `<self-uri>` output in `<pub-history>`.