### PR TITLE
Calculate the journal volume from docmap data.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.49.0"
+__version__ = "0.50.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Two functions to make testing easier, one takes a docmap string as input, the other takes a list of history event data.

The `START_YEAR` constant is configured to calculate the volume of an eLife article from the year of an event date.

Re issue https://github.com/elifesciences/issues/issues/8420