### PR TITLE
Fig caption fix

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.50.0"
+__version__ = "0.51.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/fig.py
+++ b/elifecleaner/fig.py
@@ -229,6 +229,9 @@ def split_title_parts(xml_string):
     # append the final content
     if title_parts:
         title_parts[-1] += string_part
+    elif string_part:
+        # only one string found
+        title_parts.append(string_part)
 
     return title_parts
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docmaptools==0.12.0
+docmaptools==0.15.0
 elifetools==0.32.0
 elifearticle==0.14.0
 jatsgenerator==0.6.0

--- a/tests/test_fig.py
+++ b/tests/test_fig.py
@@ -445,6 +445,13 @@ class TestSplitTtitleParts(unittest.TestCase):
         result = fig.split_title_parts(xml_string)
         self.assertEqual(result, expected)
 
+    def test_no_full_stop(self):
+        "test splitting string wiht no full stop"
+        xml_string = "<p>Test</p>"
+        expected = ["<p>Test</p>"]
+        result = fig.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
 
 class TestTitleParagraphContent(unittest.TestCase):
     "tests for fig.title_paragraph_content()"


### PR DESCRIPTION
If a fig caption paragraph is a simple sentence with no full stop, it was omitted. The fix is to keep the one simple sentence.