### PR TITLE
table module, block module, refactored fig.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/block.py
+++ b/elifecleaner/block.py
@@ -1,0 +1,281 @@
+import re
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, SubElement
+from elifecleaner import LOGGER, utils
+
+
+FIG_LABEL_CONTENT_PATTERN = r"[A-Za-z ]+ image [0-9]+?\.{0,1}"
+
+
+def match_fig_label_content(content):
+    "check if the content is a label for a figure"
+    return bool(re.match(FIG_LABEL_CONTENT_PATTERN, content)) if content else False
+
+
+TABLE_LABEL_CONTENT_PATTERN = r"[A-Za-z ]+ table [0-9]+?\.{0,1}"
+
+
+def match_table_label_content(content):
+    "check if the content is a label for a table"
+    return bool(re.match(TABLE_LABEL_CONTENT_PATTERN, content)) if content else False
+
+
+def is_p_label(tag, sub_article_id, p_tag_index, block_type, identifier):
+    "check if the p tag contents is a label"
+    label = None
+    if tag.find("bold") is not None:
+        label = tag.find("bold").text
+        LOGGER.info(
+            '%s potential label "%s" in p tag %s of id %s',
+            identifier,
+            label,
+            p_tag_index,
+            sub_article_id,
+        )
+    if block_type == "fig":
+        return match_fig_label_content(label)
+    elif block_type == "table":
+        return match_table_label_content(label)
+    return None
+
+
+def is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier):
+    "check if the p tag contains only an inline-graphic tag"
+    # simple check for a tag first
+    if tag.find("inline-graphic") is None:
+        LOGGER.info(
+            "%s no inline-graphic tag found in p tag %s of id %s",
+            identifier,
+            p_tag_index,
+            sub_article_id,
+        )
+        return False
+    # check if the p tag contains an inline-grpahic only, ignoring whitespace
+    if (
+        tag.find("inline-graphic") is not None
+        and (not tag.text or not tag.text.rstrip())
+        and (
+            not tag.find("inline-graphic").tail
+            or not tag.find("inline-graphic").tail.rstrip()
+        )
+    ):
+        LOGGER.info(
+            "%s only inline-graphic tag found in p tag %s of id %s",
+            identifier,
+            p_tag_index,
+            sub_article_id,
+        )
+        return True
+    # default return None
+    return None
+
+
+def sub_article_tag_parts(sub_article_root):
+    "return the id and body tag from a sub-article tag"
+    sub_article_id = sub_article_root.get("id")
+    body_tag = sub_article_root.find("body")
+    return sub_article_id, body_tag
+
+
+def tag_index_groups(body_tag, sub_article_id, block_type, identifier):
+    "iterate through the tags in body_tag and find groups of tags to be converted to a fig"
+    fig_index_groups = []
+    if not body_tag:
+        return fig_index_groups
+    label_index = None
+    caption_index = None
+    for tag_index, child_tag in enumerate(body_tag.iterfind("*")):
+        if child_tag.tag == "p":
+            if label_index is None:
+                # match figure label
+                if is_p_label(
+                    child_tag, sub_article_id, tag_index, block_type, identifier
+                ):
+                    label_index = tag_index
+                    LOGGER.info(
+                        "%s label p tag index %s of id %s",
+                        identifier,
+                        label_index,
+                        sub_article_id,
+                    )
+            elif label_index is not None and caption_index is None:
+                # look for optional caption
+                if not is_p_inline_graphic(
+                    child_tag, sub_article_id, tag_index, identifier
+                ):
+                    caption_index = tag_index
+                    # loop to the next p tag
+                    continue
+                # if no caption found, check this p tag for an inline-graphic below
+                caption_index = False
+            if label_index is not None and caption_index is not None:
+                # look for inline graphic to be converted to fig
+                if is_p_inline_graphic(
+                    child_tag, sub_article_id, tag_index, identifier
+                ):
+                    # add to the fig index group
+                    fig_p_data = {
+                        "label_index": label_index,
+                        "caption_index": caption_index,
+                        "inline_graphic_index": tag_index,
+                    }
+                    fig_index_groups.append(fig_p_data)
+                # reset the indexes
+                label_index = None
+                caption_index = None
+        else:
+            # if is not a p tag, reset the indexes
+            label_index = None
+            caption_index = None
+    return fig_index_groups
+
+
+def title_paragraph_content(string_list):
+    "from list of strings repair inline formatting tags and split into title and paragraph"
+    # check for nested inline formatting tags
+    title_content = ""
+    content_remainders = []
+    for title_part in string_list:
+        if not title_content:
+            title_content += title_part
+            continue
+        open_tag_count = title_content.count(utils.open_tag("italic"))
+        close_tag_count = title_content.count(utils.close_tag("italic"))
+        open_bold_tag_count = title_content.count(utils.open_tag("bold"))
+        close_bold_tag_count = title_content.count(utils.close_tag("bold"))
+        open_ext_link_tag_count = title_content.count(
+            utils.open_tag("ext-link").rstrip(">")
+        )
+        close_ext_link_tag_count = title_content.count(utils.close_tag("ext-link"))
+        if (
+            open_tag_count != close_tag_count
+            or open_bold_tag_count != close_bold_tag_count
+            or open_ext_link_tag_count != close_ext_link_tag_count
+        ):
+            title_content += title_part
+        else:
+            content_remainders.append(title_part)
+    title_content = title_content.lstrip()
+    paragraph_content = None
+    if content_remainders:
+        paragraph_content = "".join(content_remainders)
+    return title_content, paragraph_content
+
+
+def set_graphic_tag(parent, image_href, new_file_name):
+    "add a graphic tag to the parent"
+    graphic_tag = SubElement(parent, "graphic")
+    graphic_tag.set("mimetype", "image")
+    graphic_tag.set("mime-subtype", utils.file_extension(image_href))
+    graphic_tag.set("{http://www.w3.org/1999/xlink}href", new_file_name)
+
+
+def caption_title_paragraph(tag):
+    "split the content into title and optional paragraph for a fig caption"
+    xml_string = ElementTree.tostring(tag)
+    if isinstance(xml_string, bytes):
+        xml_string = str(xml_string, encoding="utf-8")
+
+    # split the string into parts
+    string_list = split_title_parts(xml_string)
+
+    title_content, paragraph_content = title_paragraph_content(string_list)
+
+    # fix enclosing tags
+    if paragraph_content:
+        title_content = "%s</p>" % title_content
+        paragraph_content = "<p %s>%s" % (
+            utils.namespace_string(),
+            paragraph_content.lstrip(),
+        )
+    # parse XML string back into an Element
+    caption_title_p_tag = ElementTree.fromstring(title_content)
+    caption_paragraph_p_tag = None
+    if paragraph_content:
+        caption_paragraph_p_tag = ElementTree.fromstring(paragraph_content)
+
+    return caption_title_p_tag, caption_paragraph_p_tag
+
+
+def set_caption_tag(parent, body_tag, caption_index):
+    "add a caption tag to the parent"
+    caption_tag = SubElement(parent, "caption")
+
+    # split into title and p tag portions
+    caption_title_p_tag, caption_paragraph_p_tag = caption_title_paragraph(
+        body_tag[caption_index]
+    )
+
+    caption_title_tag = SubElement(caption_tag, "title")
+    caption_title_tag.text = caption_title_p_tag.text
+    # handle if there are child tags in the title
+    for child_tag in caption_title_p_tag.iterfind("*"):
+        caption_title_tag.append(child_tag)
+        caption_title_tag.tail = caption_title_p_tag.tail
+    if caption_paragraph_p_tag is not None and caption_paragraph_p_tag.text:
+        caption_p_tag = SubElement(caption_tag, "p")
+        caption_p_tag.text = caption_paragraph_p_tag.text
+        # handle if there are child tags in the caption
+        for child_tag in caption_paragraph_p_tag.iterfind("*"):
+            caption_p_tag.append(child_tag)
+            caption_p_tag.tail = caption_paragraph_p_tag.tail
+
+
+def split_title_parts(xml_string):
+    "split the XML string into parts to be processed by caption_title_paragraph()"
+    title_parts = []
+    tag_match_pattern = re.compile(r"(<.*?>)")
+    match_tag_groups = tag_match_pattern.split(xml_string)
+    string_part = ""
+    for tag_group in match_tag_groups:
+        if "." in tag_group and "<" not in tag_group:
+            if tag_group == ".":
+                dot_parts = ["."]
+            else:
+                dot_parts = tag_group.split(".")
+
+            for dot_index, dot_part in enumerate(dot_parts):
+                suffix = ""
+                if dot_index + 1 < len(dot_parts):
+                    suffix = "."
+                string_part += "%s%s" % (dot_part, suffix)
+                title_parts.append(string_part)
+                string_part = ""
+        else:
+            string_part += tag_group
+    # append the final content
+    if title_parts:
+        title_parts[-1] += string_part
+    elif string_part:
+        # only one string found
+        title_parts.append(string_part)
+
+    return title_parts
+
+
+def strip_tag_text(tag):
+    "remove whitespace to the left of the child tag if present"
+    if isinstance(tag, Element) and tag.text is not None and not tag.text.rstrip():
+        tag.text = None
+
+
+def strip_tag_tail(tag):
+    "remove whitespace to the right of the tag if present"
+    if isinstance(tag, Element) and tag.tail is not None and not tag.tail.rstrip():
+        tag.tail = None
+
+
+def inline_graphic_tag_from_tag(tag):
+    "get the inline-graphic tag from the parent tag"
+    strip_tag_text(tag)
+    inline_graphic_tag = tag.find("inline-graphic")
+    strip_tag_tail(inline_graphic_tag)
+    return inline_graphic_tag
+
+
+def set_label_tag(parent, body_tag, label_index):
+    "add a label tag to the parent"
+    # insert tags into original inline-graphic
+    label_tag = SubElement(parent, "label")
+    # copy content from the label_index p tag
+    label_tag.text = body_tag[label_index].find("bold").text

--- a/elifecleaner/fig.py
+++ b/elifecleaner/fig.py
@@ -1,7 +1,5 @@
-import re
-from xml.etree import ElementTree
-from xml.etree.ElementTree import Element, SubElement
-from elifecleaner import LOGGER, utils
+from xml.etree.ElementTree import Element
+from elifecleaner import block, utils
 
 
 def inf_file_identifier(inf_file_name):
@@ -26,121 +24,9 @@ def fig_file_name(inf_file_name, sub_article_id, fig_index):
     )
 
 
-FIG_LABEL_CONTENT_PATTERN = r"[A-Za-z ]+ image [0-9]+?\.{0,1}"
-
-
-def match_fig_label_content(content):
-    "check if the content is a label for a figure"
-    return bool(re.match(FIG_LABEL_CONTENT_PATTERN, content)) if content else False
-
-
-def is_p_label(tag, sub_article_id, p_tag_index, identifier):
-    "check if the p tag contents is a label"
-    label = None
-    if tag.find("bold") is not None:
-        label = tag.find("bold").text
-        LOGGER.info(
-            '%s potential label "%s" in p tag %s of id %s',
-            identifier,
-            label,
-            p_tag_index,
-            sub_article_id,
-        )
-    return match_fig_label_content(label)
-
-
-def is_p_inline_graphic(tag, sub_article_id, p_tag_index, identifier):
-    "check if the p tag contains only an inline-graphic tag"
-    # simple check for a tag first
-    if tag.find("inline-graphic") is None:
-        LOGGER.info(
-            "%s no inline-graphic tag found in p tag %s of id %s",
-            identifier,
-            p_tag_index,
-            sub_article_id,
-        )
-        return False
-    # check if the p tag contains an inline-grpahic only, ignoring whitespace
-    if (
-        tag.find("inline-graphic") is not None
-        and (not tag.text or not tag.text.rstrip())
-        and (
-            not tag.find("inline-graphic").tail
-            or not tag.find("inline-graphic").tail.rstrip()
-        )
-    ):
-        LOGGER.info(
-            "%s only inline-graphic tag found in p tag %s of id %s",
-            identifier,
-            p_tag_index,
-            sub_article_id,
-        )
-        return True
-    # default return None
-    return None
-
-
 def fig_tag_index_groups(body_tag, sub_article_id, identifier):
     "iterate through the tags in body_tag and find groups of tags to be converted to a fig"
-    fig_index_groups = []
-    if not body_tag:
-        return fig_index_groups
-    label_index = None
-    caption_index = None
-    for tag_index, child_tag in enumerate(body_tag.iterfind("*")):
-        if child_tag.tag == "p":
-            if label_index is None:
-                # match figure label
-                if is_p_label(child_tag, sub_article_id, tag_index, identifier):
-                    label_index = tag_index
-                    LOGGER.info(
-                        "%s label p tag index %s of id %s",
-                        identifier,
-                        label_index,
-                        sub_article_id,
-                    )
-            elif label_index is not None and caption_index is None:
-                # look for optional caption
-                if not is_p_inline_graphic(
-                    child_tag, sub_article_id, tag_index, identifier
-                ):
-                    caption_index = tag_index
-                    # loop to the next p tag
-                    continue
-                # if no caption found, check this p tag for an inline-graphic below
-                caption_index = False
-            if label_index is not None and caption_index is not None:
-                # look for inline graphic to be converted to fig
-                if is_p_inline_graphic(
-                    child_tag, sub_article_id, tag_index, identifier
-                ):
-                    # add to the fig index group
-                    fig_p_data = {
-                        "label_index": label_index,
-                        "caption_index": caption_index,
-                        "inline_graphic_index": tag_index,
-                    }
-                    fig_index_groups.append(fig_p_data)
-                # reset the indexes
-                label_index = None
-                caption_index = None
-        else:
-            # if is not a p tag, reset the indexes
-            label_index = None
-            caption_index = None
-    return fig_index_groups
-
-
-def strip_tag_text(tag):
-    "remove whitespace to the left of the child tag if present"
-    if isinstance(tag, Element) and tag.text is not None and not tag.text.rstrip():
-        tag.text = None
-
-
-def strip_tag_tail(tag):
-    "remove whitespace to the right of the tag if present"
-    if isinstance(tag, Element) and tag.tail is not None and not tag.tail.rstrip():
-        tag.tail = None
+    return block.tag_index_groups(body_tag, sub_article_id, "fig", identifier)
 
 
 def remove_tag_attributes(tag):
@@ -152,24 +38,9 @@ def remove_tag_attributes(tag):
         del tag.attrib[attrib_name]
 
 
-def inline_graphic_tag_from_tag(tag):
-    "get the inline-graphic tag from the parent tag"
-    strip_tag_text(tag)
-    inline_graphic_tag = tag.find("inline-graphic")
-    strip_tag_tail(inline_graphic_tag)
-    return inline_graphic_tag
-
-
-def sub_article_tag_parts(sub_article_root):
-    "return the id and body tag from a sub-article tag"
-    sub_article_id = sub_article_root.get("id")
-    body_tag = sub_article_root.find("body")
-    return sub_article_id, body_tag
-
-
 def inline_graphic_hrefs(sub_article_root, identifier):
     "get inline-graphic href values"
-    sub_article_id, body_tag = sub_article_tag_parts(sub_article_root)
+    sub_article_id, body_tag = block.sub_article_tag_parts(sub_article_root)
     href_list = []
     if body_tag is not None:
         # match paragraphs with fig data in them and record the tag indexes
@@ -177,7 +48,7 @@ def inline_graphic_hrefs(sub_article_root, identifier):
         for group in fig_index_groups:
             if group.get("inline_graphic_index"):
                 inline_graphic_p = body_tag[group.get("inline_graphic_index")]
-                inline_graphic_tag = inline_graphic_tag_from_tag(inline_graphic_p)
+                inline_graphic_tag = block.inline_graphic_tag_from_tag(inline_graphic_p)
                 image_href = utils.xlink_href(inline_graphic_tag)
                 if image_href:
                     href_list.append(image_href)
@@ -186,7 +57,7 @@ def inline_graphic_hrefs(sub_article_root, identifier):
 
 def graphic_hrefs(sub_article_root, identifier):
     "get graphic href values"
-    sub_article_id, body_tag = sub_article_tag_parts(sub_article_root)
+    sub_article_id, body_tag = block.sub_article_tag_parts(sub_article_root)
     href_list = []
     if body_tag is not None:
         for graphic_tag in body_tag.findall(".//graphic"):
@@ -196,155 +67,26 @@ def graphic_hrefs(sub_article_root, identifier):
     return href_list
 
 
-def set_label_tag(parent, body_tag, label_index):
-    "add a label tag to the parent"
-    # insert tags into original inline-graphic
-    label_tag = SubElement(parent, "label")
-    # copy content from the label_index p tag
-    label_tag.text = body_tag[label_index].find("bold").text
-
-
-def split_title_parts(xml_string):
-    "split the XML string into parts to be processed by caption_title_paragraph()"
-    title_parts = []
-    tag_match_pattern = re.compile(r"(<.*?>)")
-    match_tag_groups = tag_match_pattern.split(xml_string)
-    string_part = ""
-    for tag_group in match_tag_groups:
-        if "." in tag_group and "<" not in tag_group:
-            if tag_group == ".":
-                dot_parts = ["."]
-            else:
-                dot_parts = tag_group.split(".")
-
-            for dot_index, dot_part in enumerate(dot_parts):
-                suffix = ""
-                if dot_index + 1 < len(dot_parts):
-                    suffix = "."
-                string_part += "%s%s" % (dot_part, suffix)
-                title_parts.append(string_part)
-                string_part = ""
-        else:
-            string_part += tag_group
-    # append the final content
-    if title_parts:
-        title_parts[-1] += string_part
-    elif string_part:
-        # only one string found
-        title_parts.append(string_part)
-
-    return title_parts
-
-
-def title_paragraph_content(string_list):
-    "from list of strings repair inline formatting tags and split into title and paragraph"
-    # check for nested inline formatting tags
-    title_content = ""
-    content_remainders = []
-    for title_part in string_list:
-        if not title_content:
-            title_content += title_part
-            continue
-        open_tag_count = title_content.count(utils.open_tag("italic"))
-        close_tag_count = title_content.count(utils.close_tag("italic"))
-        open_bold_tag_count = title_content.count(utils.open_tag("bold"))
-        close_bold_tag_count = title_content.count(utils.close_tag("bold"))
-        open_ext_link_tag_count = title_content.count(
-            utils.open_tag("ext-link").rstrip(">")
-        )
-        close_ext_link_tag_count = title_content.count(utils.close_tag("ext-link"))
-        if (
-            open_tag_count != close_tag_count
-            or open_bold_tag_count != close_bold_tag_count
-            or open_ext_link_tag_count != close_ext_link_tag_count
-        ):
-            title_content += title_part
-        else:
-            content_remainders.append(title_part)
-    title_content = title_content.lstrip()
-    paragraph_content = None
-    if content_remainders:
-        paragraph_content = "".join(content_remainders)
-    return title_content, paragraph_content
-
-
-def caption_title_paragraph(tag):
-    "split the content into title and optional paragraph for a fig caption"
-    xml_string = ElementTree.tostring(tag)
-    if isinstance(xml_string, bytes):
-        xml_string = str(xml_string, encoding="utf-8")
-
-    # split the string into parts
-    string_list = split_title_parts(xml_string)
-
-    title_content, paragraph_content = title_paragraph_content(string_list)
-
-    # fix enclosing tags
-    if paragraph_content:
-        title_content = "%s</p>" % title_content
-        paragraph_content = "<p %s>%s" % (
-            utils.namespace_string(),
-            paragraph_content.lstrip(),
-        )
-    # parse XML string back into an Element
-    caption_title_p_tag = ElementTree.fromstring(title_content)
-    caption_paragraph_p_tag = None
-    if paragraph_content:
-        caption_paragraph_p_tag = ElementTree.fromstring(paragraph_content)
-
-    return caption_title_p_tag, caption_paragraph_p_tag
-
-
-def set_caption_tag(parent, body_tag, caption_index):
-    "add a caption tag to the parent"
-    caption_tag = SubElement(parent, "caption")
-
-    # split into title and p tag portions
-    caption_title_p_tag, caption_paragraph_p_tag = caption_title_paragraph(
-        body_tag[caption_index]
-    )
-
-    caption_title_tag = SubElement(caption_tag, "title")
-    caption_title_tag.text = caption_title_p_tag.text
-    # handle if there are child tags in the title
-    for child_tag in caption_title_p_tag.iterfind("*"):
-        caption_title_tag.append(child_tag)
-        caption_title_tag.tail = caption_title_p_tag.tail
-    if caption_paragraph_p_tag is not None and caption_paragraph_p_tag.text:
-        caption_p_tag = SubElement(caption_tag, "p")
-        caption_p_tag.text = caption_paragraph_p_tag.text
-        # handle if there are child tags in the caption
-        for child_tag in caption_paragraph_p_tag.iterfind("*"):
-            caption_p_tag.append(child_tag)
-            caption_p_tag.tail = caption_paragraph_p_tag.tail
-
-
-def set_graphic_tag(parent, image_href, new_file_name):
-    "add a graphic tag to the parent"
-    graphic_tag = SubElement(parent, "graphic")
-    graphic_tag.set("mimetype", "image")
-    graphic_tag.set("mime-subtype", utils.file_extension(image_href))
-    graphic_tag.set("{http://www.w3.org/1999/xlink}href", new_file_name)
-
-
 def transform_fig_group(body_tag, fig_index, fig_group, sub_article_id):
     "transform one set of p tags into fig tags as specified in the fig_group dict"
     inline_graphic_p_tag = body_tag[fig_group.get("inline_graphic_index")]
-    inline_graphic_tag = inline_graphic_tag_from_tag(inline_graphic_p_tag)
+    inline_graphic_tag = block.inline_graphic_tag_from_tag(inline_graphic_p_tag)
     image_href = utils.xlink_href(inline_graphic_tag)
 
     # insert tags into original inline-graphic
-    set_label_tag(inline_graphic_p_tag, body_tag, fig_group.get("label_index"))
+    block.set_label_tag(inline_graphic_p_tag, body_tag, fig_group.get("label_index"))
 
     # caption
     if fig_group.get("caption_index"):
-        set_caption_tag(inline_graphic_p_tag, body_tag, fig_group.get("caption_index"))
+        block.set_caption_tag(
+            inline_graphic_p_tag, body_tag, fig_group.get("caption_index")
+        )
 
     # rename the image file
     new_file_name = fig_file_name(image_href, sub_article_id, fig_index)
 
     # graphic tag
-    set_graphic_tag(inline_graphic_p_tag, image_href, new_file_name)
+    block.set_graphic_tag(inline_graphic_p_tag, image_href, new_file_name)
 
     # convert inline-graphic p tag to a fig tag and remove attributes
     inline_graphic_p_tag.tag = "fig"
@@ -371,7 +113,7 @@ def transform_fig_groups(body_tag, fig_index_groups, sub_article_id):
 
 def transform_fig(sub_article_root, identifier):
     "transform inline-graphic tags and related p tags into a fig tag"
-    sub_article_id, body_tag = sub_article_tag_parts(sub_article_root)
+    sub_article_id, body_tag = block.sub_article_tag_parts(sub_article_root)
     if body_tag is not None:
         # match paragraphs with fig data in them and record the tag indexes
         fig_index_groups = fig_tag_index_groups(body_tag, sub_article_id, identifier)

--- a/elifecleaner/table.py
+++ b/elifecleaner/table.py
@@ -1,0 +1,65 @@
+from elifecleaner import block, utils
+
+
+def table_wrap_id(sub_article_id, table_index):
+    "create an id attribute for a table-wrap tag"
+    return "%stable%s" % (sub_article_id, table_index)
+
+
+def table_tag_index_groups(body_tag, sub_article_id, identifier):
+    "iterate through the tags in body_tag and find groups of tags to be converted to a table-wrap"
+    return block.tag_index_groups(body_tag, sub_article_id, "table", identifier)
+
+
+def transform_table_group(body_tag, table_index, table_group, sub_article_id):
+    "transform one set of p tags into table-wrap tags as specified in the table_group dict"
+    inline_graphic_p_tag = body_tag[table_group.get("inline_graphic_index")]
+    inline_graphic_tag = block.inline_graphic_tag_from_tag(inline_graphic_p_tag)
+    image_href = utils.xlink_href(inline_graphic_tag)
+
+    # insert tags into original inline-graphic
+    block.set_label_tag(inline_graphic_p_tag, body_tag, table_group.get("label_index"))
+
+    # caption
+    if table_group.get("caption_index"):
+        block.set_caption_tag(
+            inline_graphic_p_tag, body_tag, table_group.get("caption_index")
+        )
+
+    # graphic tag
+    new_file_name = image_href
+    block.set_graphic_tag(inline_graphic_p_tag, image_href, new_file_name)
+
+    # convert inline-graphic p tag to a table-wrap tag
+    inline_graphic_p_tag.tag = "table-wrap"
+    inline_graphic_p_tag.set("id", table_wrap_id(sub_article_id, table_index))
+
+    # delete the old inline-graphic tag
+    inline_graphic_p_tag.remove(inline_graphic_tag)
+
+    # remove the old p tags
+    if table_group.get("caption_index"):
+        del body_tag[table_group.get("caption_index")]
+    del body_tag[table_group.get("label_index")]
+
+
+def transform_table_groups(body_tag, table_index_groups, sub_article_id):
+    "transform p tags in the body_tag to table-wrap tags as listed in table_index_groups"
+    # transform the table tags in reverse order
+    table_index = len(table_index_groups)
+    for table_group in reversed(table_index_groups):
+        transform_table_group(body_tag, table_index, table_group, sub_article_id)
+        # decrement the index
+        table_index -= 1
+
+
+def transform_table(sub_article_root, identifier):
+    "transform inline-graphic tags and related p tags into a table-wrap tag"
+    sub_article_id, body_tag = block.sub_article_tag_parts(sub_article_root)
+    if body_tag is not None:
+        # match paragraphs with data in them and record the tag indexes
+        table_index_groups = table_tag_index_groups(
+            body_tag, sub_article_id, identifier
+        )
+        transform_table_groups(body_tag, table_index_groups, sub_article_id)
+    return sub_article_root

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -50,3 +50,14 @@ def read_log_file_lines(log_file_path):
         for line in open_file:
             log_file_lines.append(line)
     return log_file_lines
+
+
+def sub_article_xml_fixture(
+    article_type, sub_article_id, front_stub_xml_string, body_xml_string
+):
+    "generate test fixture XML for a sub-article"
+    return (
+        b'<sub-article xmlns:xlink="http://www.w3.org/1999/xlink" '
+        b'article-type="%s" id="%s">%s%s</sub-article>'
+        % (article_type, sub_article_id, front_stub_xml_string, body_xml_string)
+    )

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,0 +1,516 @@
+import unittest
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+from elifetools import xmlio
+from elifecleaner import block
+
+
+class TestMatchFigLabelContent(unittest.TestCase):
+    "tests for block.match_fig_label_content()"
+
+    def test_match_fig_label_content(self):
+        "test matching paragraph content as a fig label"
+        cases = [
+            (None, False),
+            ("", False),
+            ("Test", False),
+            ("Review image 1.", True),
+            ("Review image 1", True),
+            ("Review table 1.", False),
+            ("Author response image 1.", True),
+        ]
+        for content, expected in cases:
+            self.assertEqual(block.match_fig_label_content(content), expected)
+
+
+class TestMatchTableLabelContent(unittest.TestCase):
+    "tests for block.match_table_label_content()"
+
+    def test_match_table_label_content(self):
+        "test matching paragraph content as a table label"
+        cases = [
+            (None, False),
+            ("", False),
+            ("Test", False),
+            ("Review table 1.", True),
+            ("Review table 1", True),
+            ("Review image 1.", False),
+            ("Author response table 1.", True),
+        ]
+        for content, expected in cases:
+            self.assertEqual(
+                block.match_table_label_content(content), expected, 'on "%s"' % content
+            )
+
+
+class TestIsPLabel(unittest.TestCase):
+    "tests for block.is_p_label()"
+
+    def test_is_p_label(self):
+        "example of a matched label in a p tag"
+        xml_string = "<p><bold>Review image 1.</bold></p>"
+        block_type = "fig"
+        expected = True
+        self.assertEqual(
+            block.is_p_label(
+                ElementTree.fromstring(xml_string), None, None, block_type, None
+            ),
+            expected,
+        )
+
+    def test_table_is_p_label(self):
+        "example of a matched table label in a p tag"
+        xml_string = "<p><bold>Review table 1.</bold></p>"
+        block_type = "table"
+        expected = True
+        self.assertEqual(
+            block.is_p_label(
+                ElementTree.fromstring(xml_string), None, None, block_type, None
+            ),
+            expected,
+        )
+
+    def test_no_block_type(self):
+        "test if block_type is None"
+        xml_string = "<p><bold>Review table 1.</bold></p>"
+        block_type = None
+        expected = None
+        self.assertEqual(
+            block.is_p_label(
+                ElementTree.fromstring(xml_string), None, None, block_type, None
+            ),
+            expected,
+        )
+
+    def test_false(self):
+        "not a label in a p tag"
+        xml_string = "<p>Foo.</p>"
+        block_type = "fig"
+        expected = False
+        self.assertEqual(
+            block.is_p_label(
+                ElementTree.fromstring(xml_string), None, None, block_type, None
+            ),
+            expected,
+        )
+
+
+class TestIsPInlineGraphic(unittest.TestCase):
+    "tests for block.is_p_inline_graphic()"
+
+    def test_is_p_inline_graphic(self):
+        "simple example of an inline-graphic p tag"
+        xml_string = "<p><inline-graphic /></p>"
+        expected = True
+        self.assertEqual(
+            block.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+    def test_whitespace(self):
+        "test if when whitespace surrounds the inline-graphic tag"
+        xml_string = "<p>   <inline-graphic />      </p>"
+        expected = True
+        self.assertEqual(
+            block.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+    def test_false(self):
+        "not an inline-graphic p tag"
+        xml_string = "<p>Foo.</p>"
+        expected = False
+        self.assertEqual(
+            block.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+    def test_none(self):
+        "an inline-graphic tag and other content returns None"
+        xml_string = "<p>An <inline-graphic/></p>"
+        expected = None
+        self.assertEqual(
+            block.is_p_inline_graphic(
+                ElementTree.fromstring(xml_string), None, None, None
+            ),
+            expected,
+        )
+
+
+class TestSetGraphicTag(unittest.TestCase):
+    "tests for block.set_graphic_tag()"
+
+    def test_set_graphic_tag(self):
+        "create graphic tag for a fig"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        xml_string = '<fig xmlns:xlink="http://www.w3.org/1999/xlink" />'
+        tag = ElementTree.fromstring(xml_string)
+        image_href = "image.png"
+        new_file_name = "new_image.png"
+        expected = (
+            b'<fig xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b'<graphic mimetype="image" mime-subtype="png" xlink:href="new_image.png" />'
+            b"</fig>"
+        )
+        block.set_graphic_tag(tag, image_href, new_file_name)
+        self.assertEqual(ElementTree.tostring(tag), expected)
+
+
+class TestSetCaptionTag(unittest.TestCase):
+    "tests for block.set_caption_tag()"
+
+    def test_set_caption_tag(self):
+        "create caption tag for a fig"
+        body_tag_xml_string = (
+            b"<body>"
+            b"<p>Title <italic>here</italic>. "
+            b"Caption paragraph <italic>ici</italic>."
+            b"</p>"
+            b"</body>"
+        )
+        body_tag = ElementTree.fromstring(body_tag_xml_string)
+        tag = Element("fig")
+        caption_index = 0
+        expected = (
+            b"<fig>"
+            b"<caption>"
+            b"<title>Title <italic>here</italic>.</title>"
+            b"<p>Caption paragraph <italic>ici</italic>.</p>"
+            b"</caption>"
+            b"</fig>"
+        )
+        block.set_caption_tag(tag, body_tag, caption_index)
+        self.assertEqual(ElementTree.tostring(tag), expected)
+
+
+class TestSubArticleTagParts(unittest.TestCase):
+    "tests for block.sub_article_tag_parts()"
+
+    def test_sub_article_tag_parts(self):
+        "test parsing sub-article XML tag data"
+        id_value = "sa0"
+        xml_string = '<sub-article id="%s"><body/></sub-article>' % id_value
+        sub_article_root = ElementTree.fromstring(xml_string)
+        result = block.sub_article_tag_parts(sub_article_root)
+        self.assertEqual(result[0], id_value)
+        self.assertTrue(isinstance(result[1], Element))
+        self.assertEqual(result[1].tag, "body")
+
+
+class TestTagIndexGroups(unittest.TestCase):
+    "tests for block.tag_index_groups()"
+
+    def setUp(self):
+        self.sub_article_id = "sa0"
+        self.identifier = "test.zip"
+
+    def test_tag_index_groups(self):
+        "test body XML tag with fig content"
+        xml_string = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<blockquote><p>Quotation.</p></blockquote>"
+            "<p><bold>Author response image 1.</bold></p>"
+            "<p>Caption title. Caption paragraph <italic>here</italic>.</p>"
+            '<p><inline-graphic xlink:href="test.png"/></p>'
+            "</body>"
+        )
+        block_type = "fig"
+        expected = [{"label_index": 1, "caption_index": 2, "inline_graphic_index": 3}]
+        body_tag = ElementTree.fromstring(xml_string)
+        result = block.tag_index_groups(
+            body_tag, self.sub_article_id, block_type, self.identifier
+        )
+        self.assertDictEqual(result[0], expected[0])
+
+    def test_table_no_caption(self):
+        "test body XML tag with a table and no caption"
+        xml_string = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p><bold>Author response table 1.</bold></p>"
+            '<p><inline-graphic xlink:href="test.png"/></p>'
+            "</body>"
+        )
+        block_type = "table"
+        expected = {"label_index": 0, "caption_index": False, "inline_graphic_index": 1}
+        body_tag = ElementTree.fromstring(xml_string)
+        result = block.tag_index_groups(
+            body_tag, self.sub_article_id, block_type, self.identifier
+        )
+        self.assertDictEqual(result[0], expected)
+
+    def test_empty_body_tag(self):
+        "test body XML tag with no tags inside"
+        xml_string = "<body></body>"
+        block_type = "fig"
+        expected = []
+        body_tag = ElementTree.fromstring(xml_string)
+        result = block.tag_index_groups(
+            body_tag, self.sub_article_id, block_type, self.identifier
+        )
+        self.assertEqual(result, expected)
+
+
+class TestTitleParagraphContent(unittest.TestCase):
+    "tests for block.title_paragraph_content()"
+
+    def test_title_paragraph_content(self):
+        "a simple example of string parts"
+        string_list = [
+            "<p>Caption title.",
+            " Caption paragraph.",
+            "</p>",
+        ]
+        expected = ("<p>Caption title.", " Caption paragraph.</p>")
+        result = block.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+    def test_multiple_sentences(self):
+        "a simple example of string parts"
+        string_list = [
+            "<p>A title.",
+            " A caption paragraph.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        expected = ("<p>A title.", " A caption paragraph. Another paragraph.</p>")
+        result = block.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+    def test_italic(self):
+        "test where an unmatched inline formatting tag is repaired"
+        string_list = [
+            "<p>The title<bold>.",
+            "</bold> Another <bold>bold term</bold>.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        expected = (
+            "<p>The title<bold>.</bold> Another <bold>bold term</bold>.",
+            " Another paragraph.</p>",
+        )
+        result = block.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+    def test_empty_list(self):
+        "test an empty list"
+        string_list = [""]
+        expected = ("", None)
+        result = block.title_paragraph_content(string_list)
+        self.assertEqual(result, expected)
+
+
+class TestCaptionTitleParagraph(unittest.TestCase):
+    "tests for block.caption_title_paragraph()"
+
+    def setUp(self):
+        # register XML namespaces
+        xmlio.register_xmlns()
+
+    def test_simple_title(self):
+        "test a simple example"
+        xml_string = "<p>Title. Caption.</p>"
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = block.caption_title_paragraph(
+            tag
+        )
+        self.assertEqual(ElementTree.tostring(caption_title_p_tag), b"<p>Title.</p>")
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Caption.</p>"
+        )
+
+    def test_organism_title(self):
+        "test for italic tag included"
+        xml_string = "<p>In <italic>B. subtilis</italic>, the title. Caption.</p>"
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = block.caption_title_paragraph(
+            tag
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b"<p>In <italic>B. subtilis</italic>, the title.</p>",
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Caption.</p>"
+        )
+
+    def test_two_bold_tags(self):
+        "edge case with more than one bold tag and second one is around the title full stop"
+        xml_string = (
+            "<p>The title<bold>.</bold> Another <bold>bold term</bold>."
+            " Another paragraph.</p>"
+        )
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = block.caption_title_paragraph(
+            tag
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b"<p>The title<bold>.</bold> Another <bold>bold term</bold>.</p>",
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Another paragraph.</p>"
+        )
+
+    def test_ext_link_tag(self):
+        "edge case with an ext-link tag in the title and challenging full stop separations"
+        xml_string = '<p xmlns:xlink="http://www.w3.org/1999/xlink">(Figure 2A from <ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>)<bold>.</bold> Comparison of Tests against Γ ( 4,5) (a = 0.05). The normality tests used were severely underpowered for n&lt;100 (<ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>).</p>'
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = block.caption_title_paragraph(
+            tag
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b'<p xmlns:xlink="http://www.w3.org/1999/xlink">(Figure 2A from <ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>)<bold>.</bold> Comparison of Tests against &#915; ( 4,5) (a = 0.</p>',
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_paragraph_p_tag),
+            b'<p xmlns:xlink="http://www.w3.org/1999/xlink">05). The normality tests used were severely underpowered for n&lt;100 (<ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>).</p>',
+        )
+
+    def test_mml_tag(self):
+        "edge case where a full stop in math formula should not be used as separate parts"
+        xml_string = '<p xmlns:mml="http://www.w3.org/1998/Math/MathML">For one participant <inline-formula><mml:math alttext="" display="inline"><mml:mspace width="0.222em" /></mml:math></inline-formula> is a formula.</p>'
+        tag = ElementTree.fromstring(xml_string)
+        caption_title_p_tag, caption_paragraph_p_tag = block.caption_title_paragraph(
+            tag
+        )
+        self.assertEqual(
+            ElementTree.tostring(caption_title_p_tag),
+            b'<p xmlns:mml="http://www.w3.org/1998/Math/MathML">For one participant <inline-formula><mml:math alttext="" display="inline"><mml:mspace width="0.222em" /></mml:math></inline-formula> is a formula.</p>',
+        )
+        self.assertEqual(ElementTree.tostring(caption_paragraph_p_tag), b"<p />")
+
+
+class TestSplitTtitleParts(unittest.TestCase):
+    "tests for block.split_title_parts()"
+
+    def test_split_title_parts(self):
+        "test spliting a simple example"
+        xml_string = "<p>A title. A caption paragraph.</p>"
+        expected = ["<p>A title.", " A caption paragraph.", "</p>"]
+        result = block.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_multiple_sentences(self):
+        "test spliting a simple example"
+        xml_string = "<p>A title. A caption paragraph. Another paragraph.</p>"
+        expected = [
+            "<p>A title.",
+            " A caption paragraph.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        result = block.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_namespace(self):
+        "test spliting a simple example"
+        xml_string = (
+            '<p xmlns:xlink="http://www.w3.org/1999/xlink">'
+            'A title only (<ext-link xlink:href="http://example.org"/>).'
+            "</p>"
+        )
+        expected = [
+            '<p xmlns:xlink="http://www.w3.org/1999/xlink">A title only (<ext-link '
+            'xlink:href="http://example.org"/>).',
+            "</p>",
+        ]
+        result = block.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_unmatched_tags(self):
+        "example where there are unmatched tags in the result"
+        xml_string = xml_string = (
+            "<p>The title<bold>.</bold> Another <bold>bold term</bold>."
+            " Another paragraph.</p>"
+        )
+        expected = [
+            "<p>The title<bold>.",
+            "</bold> Another <bold>bold term</bold>.",
+            " Another paragraph.",
+            "</p>",
+        ]
+        result = block.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_blank_string(self):
+        "test splitting a blank string"
+        xml_string = ""
+        expected = []
+        result = block.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+    def test_no_full_stop(self):
+        "test splitting string wiht no full stop"
+        xml_string = "<p>Test</p>"
+        expected = ["<p>Test</p>"]
+        result = block.split_title_parts(xml_string)
+        self.assertEqual(result, expected)
+
+
+class TestStripTagText(unittest.TestCase):
+    "tests for block.strip_tag_text()"
+
+    def test_strip_tag_text(self):
+        "test an example with whitespace to the left of the tag"
+        xml_string = b"<p> <inline-graphic /> </p>"
+        expected = b"<p><inline-graphic /> </p>"
+        p_tag = ElementTree.fromstring(xml_string)
+        block.strip_tag_text(p_tag)
+        self.assertEqual(ElementTree.tostring(p_tag), expected)
+
+    def test_non_element(self):
+        "test if the input is not a tag"
+        tag = "foo"
+        self.assertEqual(block.strip_tag_text(tag), None)
+
+
+class TestStripTagTail(unittest.TestCase):
+    "tests for block.strip_tag_tail()"
+
+    def test_strip_tag_tail(self):
+        "test an example with whitespace to the left and right of the tag"
+        xml_string = b"<p> <inline-graphic /> </p>"
+        expected = b"<inline-graphic />"
+        p_tag = ElementTree.fromstring(xml_string)
+        inline_graphic_tag = p_tag.find("inline-graphic")
+        block.strip_tag_tail(inline_graphic_tag)
+        self.assertEqual(ElementTree.tostring(inline_graphic_tag), expected)
+
+    def test_non_element(self):
+        "test if the input is not a tag"
+        tag = "foo"
+        self.assertEqual(block.strip_tag_tail(tag), None)
+
+
+class TestInlineGraphicTagFromTag(unittest.TestCase):
+    "tests for block.inline_graphic_tag_from_tag()"
+
+    def test_tag_found(self):
+        "test getting a inline-graphic tag from a p tag"
+        xml_string = b"<p>   <inline-graphic />   </p>"
+        tag = ElementTree.fromstring(xml_string)
+        expected = b"<inline-graphic />"
+        result = block.inline_graphic_tag_from_tag(tag)
+        self.assertEqual(ElementTree.tostring(result), expected)
+
+
+class TestSetLabelTag(unittest.TestCase):
+    "tests for block.set_label_tag()"
+
+    def test_set_label_tag(self):
+        "create label tag for a fig"
+        body_tag_xml_string = b"<body><p><bold>Label</bold></p></body>"
+        body_tag = ElementTree.fromstring(body_tag_xml_string)
+        tag = Element("fig")
+        label_index = 0
+        expected = b"<fig><label>Label</label></fig>"
+        block.set_label_tag(tag, body_tag, label_index)
+        self.assertEqual(ElementTree.tostring(tag), expected)

--- a/tests/test_fig.py
+++ b/tests/test_fig.py
@@ -1,10 +1,13 @@
 import os
 import unittest
 from xml.etree import ElementTree
-from xml.etree.ElementTree import Element
 from elifetools import xmlio
 from elifecleaner import configure_logging, fig, LOGGER
-from tests.helpers import delete_files_in_folder, read_log_file_lines
+from tests.helpers import (
+    delete_files_in_folder,
+    read_log_file_lines,
+    sub_article_xml_fixture,
+)
 
 
 class TestInfFileIdentifier(unittest.TestCase):
@@ -41,94 +44,6 @@ class TestFigFileName(unittest.TestCase):
         expected = "elife-70493-sa2-fig1.png"
         self.assertEqual(
             fig.fig_file_name(inf_file_name, sub_article_id, fig_index),
-            expected,
-        )
-
-
-class TestMatchFigLabelContent(unittest.TestCase):
-    "tests for fig.match_fig_label_content()"
-
-    def test_match_fig_label_content(self):
-        "test matching paragraph content as a fig label"
-        cases = [
-            (None, False),
-            ("", False),
-            ("Test", False),
-            ("Review image 1.", True),
-            ("Review image 1", True),
-            ("Review table 1.", False),
-            ("Author response image 1.", True),
-        ]
-        for content, expected in cases:
-            self.assertEqual(fig.match_fig_label_content(content), expected)
-
-
-class TestIsPLabel(unittest.TestCase):
-    "tests for fig.is_p_label()"
-
-    def test_is_p_label(self):
-        "example of a matched label in a p tag"
-        xml_string = "<p><bold>Review image 1.</bold></p>"
-        expected = True
-        self.assertEqual(
-            fig.is_p_label(ElementTree.fromstring(xml_string), None, None, None),
-            expected,
-        )
-
-    def test_false(self):
-        "not a label in a p tag"
-        xml_string = "<p>Foo.</p>"
-        expected = False
-        self.assertEqual(
-            fig.is_p_label(ElementTree.fromstring(xml_string), None, None, None),
-            expected,
-        )
-
-
-class TestIsPInlineGraphic(unittest.TestCase):
-    "tests for fig.is_p_inline_graphic()"
-
-    def test_is_p_inline_graphic(self):
-        "simple example of an inline-graphic p tag"
-        xml_string = "<p><inline-graphic /></p>"
-        expected = True
-        self.assertEqual(
-            fig.is_p_inline_graphic(
-                ElementTree.fromstring(xml_string), None, None, None
-            ),
-            expected,
-        )
-
-    def test_whitespace(self):
-        "test if when whitespace surrounds the inline-graphic tag"
-        xml_string = "<p>   <inline-graphic />      </p>"
-        expected = True
-        self.assertEqual(
-            fig.is_p_inline_graphic(
-                ElementTree.fromstring(xml_string), None, None, None
-            ),
-            expected,
-        )
-
-    def test_false(self):
-        "not an inline-graphic p tag"
-        xml_string = "<p>Foo.</p>"
-        expected = False
-        self.assertEqual(
-            fig.is_p_inline_graphic(
-                ElementTree.fromstring(xml_string), None, None, None
-            ),
-            expected,
-        )
-
-    def test_none(self):
-        "an inline-graphic tag and other content returns None"
-        xml_string = "<p>An <inline-graphic/></p>"
-        expected = None
-        self.assertEqual(
-            fig.is_p_inline_graphic(
-                ElementTree.fromstring(xml_string), None, None, None
-            ),
             expected,
         )
 
@@ -243,41 +158,6 @@ class TestTransformFigGroups(unittest.TestCase):
         self.assertEqual(ElementTree.tostring(body_tag), expected)
 
 
-class TestStripTagText(unittest.TestCase):
-    "tests for fig.strip_tag_text()"
-
-    def test_strip_tag_text(self):
-        "test an example with whitespace to the left of the tag"
-        xml_string = b"<p> <inline-graphic /> </p>"
-        expected = b"<p><inline-graphic /> </p>"
-        p_tag = ElementTree.fromstring(xml_string)
-        fig.strip_tag_text(p_tag)
-        self.assertEqual(ElementTree.tostring(p_tag), expected)
-
-    def test_non_element(self):
-        "test if the input is not a tag"
-        tag = "foo"
-        self.assertEqual(fig.strip_tag_text(tag), None)
-
-
-class TestStripTagTail(unittest.TestCase):
-    "tests for fig.strip_tag_tail()"
-
-    def test_strip_tag_tail(self):
-        "test an example with whitespace to the left and right of the tag"
-        xml_string = b"<p> <inline-graphic /> </p>"
-        expected = b"<inline-graphic />"
-        p_tag = ElementTree.fromstring(xml_string)
-        inline_graphic_tag = p_tag.find("inline-graphic")
-        fig.strip_tag_tail(inline_graphic_tag)
-        self.assertEqual(ElementTree.tostring(inline_graphic_tag), expected)
-
-    def test_non_element(self):
-        "test if the input is not a tag"
-        tag = "foo"
-        self.assertEqual(fig.strip_tag_tail(tag), None)
-
-
 class TestRemoveTagAttributes(unittest.TestCase):
     "tests for fig.remove_tag_attributes()"
 
@@ -297,18 +177,6 @@ class TestRemoveTagAttributes(unittest.TestCase):
         "test if the input is not a tag"
         tag = "foo"
         self.assertEqual(fig.remove_tag_attributes(tag), None)
-
-
-class TestInlineGraphicTagFromTag(unittest.TestCase):
-    "tests for fig.inline_graphic_tag_from_tag()"
-
-    def test_tag_found(self):
-        "test getting a inline-graphic tag from a p tag"
-        xml_string = b"<p>   <inline-graphic />   </p>"
-        tag = ElementTree.fromstring(xml_string)
-        expected = b"<inline-graphic />"
-        result = fig.inline_graphic_tag_from_tag(tag)
-        self.assertEqual(ElementTree.tostring(result), expected)
 
 
 class TestInlineGraphicHrefs(unittest.TestCase):
@@ -372,251 +240,6 @@ class TestGraphicHrefs(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
-class TestSetLabelTag(unittest.TestCase):
-    "tests for fig.set_label_tag()"
-
-    def test_set_label_tag(self):
-        "create label tag for a fig"
-        body_tag_xml_string = b"<body><p><bold>Label</bold></p></body>"
-        body_tag = ElementTree.fromstring(body_tag_xml_string)
-        tag = Element("fig")
-        label_index = 0
-        expected = b"<fig><label>Label</label></fig>"
-        fig.set_label_tag(tag, body_tag, label_index)
-        self.assertEqual(ElementTree.tostring(tag), expected)
-
-
-class TestSplitTtitleParts(unittest.TestCase):
-    "tests for fig.split_title_parts()"
-
-    def test_split_title_parts(self):
-        "test spliting a simple example"
-        xml_string = "<p>A title. A caption paragraph.</p>"
-        expected = ["<p>A title.", " A caption paragraph.", "</p>"]
-        result = fig.split_title_parts(xml_string)
-        self.assertEqual(result, expected)
-
-    def test_multiple_sentences(self):
-        "test spliting a simple example"
-        xml_string = "<p>A title. A caption paragraph. Another paragraph.</p>"
-        expected = [
-            "<p>A title.",
-            " A caption paragraph.",
-            " Another paragraph.",
-            "</p>",
-        ]
-        result = fig.split_title_parts(xml_string)
-        self.assertEqual(result, expected)
-
-    def test_namespace(self):
-        "test spliting a simple example"
-        xml_string = (
-            '<p xmlns:xlink="http://www.w3.org/1999/xlink">'
-            'A title only (<ext-link xlink:href="http://example.org"/>).'
-            "</p>"
-        )
-        expected = [
-            '<p xmlns:xlink="http://www.w3.org/1999/xlink">A title only (<ext-link '
-            'xlink:href="http://example.org"/>).',
-            "</p>",
-        ]
-        result = fig.split_title_parts(xml_string)
-        self.assertEqual(result, expected)
-
-    def test_unmatched_tags(self):
-        "example where there are unmatched tags in the result"
-        xml_string = xml_string = (
-            "<p>The title<bold>.</bold> Another <bold>bold term</bold>."
-            " Another paragraph.</p>"
-        )
-        expected = [
-            "<p>The title<bold>.",
-            "</bold> Another <bold>bold term</bold>.",
-            " Another paragraph.",
-            "</p>",
-        ]
-        result = fig.split_title_parts(xml_string)
-        self.assertEqual(result, expected)
-
-    def test_blank_string(self):
-        "test splitting a blank string"
-        xml_string = ""
-        expected = []
-        result = fig.split_title_parts(xml_string)
-        self.assertEqual(result, expected)
-
-    def test_no_full_stop(self):
-        "test splitting string wiht no full stop"
-        xml_string = "<p>Test</p>"
-        expected = ["<p>Test</p>"]
-        result = fig.split_title_parts(xml_string)
-        self.assertEqual(result, expected)
-
-
-class TestTitleParagraphContent(unittest.TestCase):
-    "tests for fig.title_paragraph_content()"
-
-    def test_title_paragraph_content(self):
-        "a simple example of string parts"
-        string_list = [
-            "<p>Caption title.",
-            " Caption paragraph.",
-            "</p>",
-        ]
-        expected = ("<p>Caption title.", " Caption paragraph.</p>")
-        result = fig.title_paragraph_content(string_list)
-        self.assertEqual(result, expected)
-
-    def test_multiple_sentences(self):
-        "a simple example of string parts"
-        string_list = [
-            "<p>A title.",
-            " A caption paragraph.",
-            " Another paragraph.",
-            "</p>",
-        ]
-        expected = ("<p>A title.", " A caption paragraph. Another paragraph.</p>")
-        result = fig.title_paragraph_content(string_list)
-        self.assertEqual(result, expected)
-
-    def test_italic(self):
-        "test where an unmatched inline formatting tag is repaired"
-        string_list = [
-            "<p>The title<bold>.",
-            "</bold> Another <bold>bold term</bold>.",
-            " Another paragraph.",
-            "</p>",
-        ]
-        expected = (
-            "<p>The title<bold>.</bold> Another <bold>bold term</bold>.",
-            " Another paragraph.</p>",
-        )
-        result = fig.title_paragraph_content(string_list)
-        self.assertEqual(result, expected)
-
-    def test_empty_list(self):
-        "test an empty list"
-        string_list = [""]
-        expected = ("", None)
-        result = fig.title_paragraph_content(string_list)
-        self.assertEqual(result, expected)
-
-
-class TestCaptionTitleParagraph(unittest.TestCase):
-    "tests for fig.caption_title_paragraph()"
-
-    def test_simple_title(self):
-        "test a simple example"
-        xml_string = "<p>Title. Caption.</p>"
-        tag = ElementTree.fromstring(xml_string)
-        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
-        self.assertEqual(ElementTree.tostring(caption_title_p_tag), b"<p>Title.</p>")
-        self.assertEqual(
-            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Caption.</p>"
-        )
-
-    def test_organism_title(self):
-        "test for italic tag included"
-        xml_string = "<p>In <italic>B. subtilis</italic>, the title. Caption.</p>"
-        tag = ElementTree.fromstring(xml_string)
-        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
-        self.assertEqual(
-            ElementTree.tostring(caption_title_p_tag),
-            b"<p>In <italic>B. subtilis</italic>, the title.</p>",
-        )
-        self.assertEqual(
-            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Caption.</p>"
-        )
-
-    def test_two_bold_tags(self):
-        "edge case with more than one bold tag and second one is around the title full stop"
-        xml_string = (
-            "<p>The title<bold>.</bold> Another <bold>bold term</bold>."
-            " Another paragraph.</p>"
-        )
-        tag = ElementTree.fromstring(xml_string)
-        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
-        self.assertEqual(
-            ElementTree.tostring(caption_title_p_tag),
-            b"<p>The title<bold>.</bold> Another <bold>bold term</bold>.</p>",
-        )
-        self.assertEqual(
-            ElementTree.tostring(caption_paragraph_p_tag), b"<p>Another paragraph.</p>"
-        )
-
-    def test_ext_link_tag(self):
-        "edge case with an ext-link tag in the title and challenging full stop separations"
-        xml_string = '<p xmlns:xlink="http://www.w3.org/1999/xlink">(Figure 2A from <ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>)<bold>.</bold> Comparison of Tests against Γ ( 4,5) (a = 0.05). The normality tests used were severely underpowered for n&lt;100 (<ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>).</p>'
-        tag = ElementTree.fromstring(xml_string)
-        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
-        self.assertEqual(
-            ElementTree.tostring(caption_title_p_tag),
-            b'<p xmlns:xlink="http://www.w3.org/1999/xlink">(Figure 2A from <ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>)<bold>.</bold> Comparison of Tests against &#915; ( 4,5) (a = 0.</p>',
-        )
-        self.assertEqual(
-            ElementTree.tostring(caption_paragraph_p_tag),
-            b'<p xmlns:xlink="http://www.w3.org/1999/xlink">05). The normality tests used were severely underpowered for n&lt;100 (<ext-link ext-link-type="uri" xlink:href="https://example.org/one/two">(Anonymous et al., 2011)</ext-link>).</p>',
-        )
-
-    def test_mml_tag(self):
-        "edge case where a full stop in math formula should not be used as separate parts"
-        xml_string = '<p xmlns:mml="http://www.w3.org/1998/Math/MathML">For one participant <inline-formula><mml:math alttext="" display="inline"><mml:mspace width="0.222em" /></mml:math></inline-formula> is a formula.</p>'
-        tag = ElementTree.fromstring(xml_string)
-        caption_title_p_tag, caption_paragraph_p_tag = fig.caption_title_paragraph(tag)
-        self.assertEqual(
-            ElementTree.tostring(caption_title_p_tag),
-            b'<p xmlns:mml="http://www.w3.org/1998/Math/MathML">For one participant <inline-formula><mml:math alttext="" display="inline"><mml:mspace width="0.222em" /></mml:math></inline-formula> is a formula.</p>',
-        )
-        self.assertEqual(ElementTree.tostring(caption_paragraph_p_tag), b"<p />")
-
-
-class TestSetCaptionTag(unittest.TestCase):
-    "tests for fig.set_caption_tag()"
-
-    def test_set_caption_tag(self):
-        "create caption tag for a fig"
-        body_tag_xml_string = (
-            b"<body>"
-            b"<p>Title <italic>here</italic>. "
-            b"Caption paragraph <italic>ici</italic>."
-            b"</p>"
-            b"</body>"
-        )
-        body_tag = ElementTree.fromstring(body_tag_xml_string)
-        tag = Element("fig")
-        caption_index = 0
-        expected = (
-            b"<fig>"
-            b"<caption>"
-            b"<title>Title <italic>here</italic>.</title>"
-            b"<p>Caption paragraph <italic>ici</italic>.</p>"
-            b"</caption>"
-            b"</fig>"
-        )
-        fig.set_caption_tag(tag, body_tag, caption_index)
-        self.assertEqual(ElementTree.tostring(tag), expected)
-
-
-class TestSetGraphicTag(unittest.TestCase):
-    "tests for fig.set_graphic_tag()"
-
-    def test_set_graphic_tag(self):
-        "create graphic tag for a fig"
-        # register XML namespaces
-        xmlio.register_xmlns()
-        xml_string = '<fig xmlns:xlink="http://www.w3.org/1999/xlink" />'
-        tag = ElementTree.fromstring(xml_string)
-        image_href = "image.png"
-        new_file_name = "new_image.png"
-        expected = (
-            b'<fig xmlns:xlink="http://www.w3.org/1999/xlink">'
-            b'<graphic mimetype="image" mime-subtype="png" xlink:href="new_image.png" />'
-            b"</fig>"
-        )
-        fig.set_graphic_tag(tag, image_href, new_file_name)
-        self.assertEqual(ElementTree.tostring(tag), expected)
-
-
 class TestTransformFigGroup(unittest.TestCase):
     "tests for fig.transform_fig_group()"
 
@@ -653,17 +276,6 @@ class TestTransformFigGroup(unittest.TestCase):
 
         fig.transform_fig_group(body_tag, fig_index, fig_group, sub_article_id)
         self.assertEqual(ElementTree.tostring(body_tag), expected)
-
-
-def sub_article_xml_fixture(
-    article_type, sub_article_id, front_stub_xml_string, body_xml_string
-):
-    "generate test fixture XML for a sub-article"
-    return (
-        b'<sub-article xmlns:xlink="http://www.w3.org/1999/xlink" '
-        b'article-type="%s" id="%s">%s%s</sub-article>'
-        % (article_type, sub_article_id, front_stub_xml_string, body_xml_string)
-    )
 
 
 def sa1_sub_article_xml_fixture():
@@ -757,12 +369,12 @@ class TestTransformFig(unittest.TestCase):
             )
             in rough_xml_string.decode("utf8")
         )
-        info_prefix = "INFO elifecleaner:fig"
+        info_prefix = "INFO elifecleaner:block"
         expected = [
             '%s:%s: %s potential label "Review image 1." in p tag 1 of id sa1\n'
             % (info_prefix, "is_p_label", self.identifier),
             "%s:%s: %s label p tag index 1 of id sa1\n"
-            % (info_prefix, "fig_tag_index_groups", self.identifier),
+            % (info_prefix, "tag_index_groups", self.identifier),
             "%s:%s: %s no inline-graphic tag found in p tag 2 of id sa1\n"
             % (info_prefix, "is_p_inline_graphic", self.identifier),
             "%s:%s: %s only inline-graphic tag found in p tag 3 of id sa1\n"
@@ -816,13 +428,12 @@ class TestTransformFig(unittest.TestCase):
             )
             in rough_xml_string.decode("utf8")
         )
-        # self.assertTrue(False)
-        info_prefix = "INFO elifecleaner:fig"
+        info_prefix = "INFO elifecleaner:block"
         expected = [
             '%s:%s: %s potential label "Author response image 1." in p tag 1 of id sa4\n'
             % (info_prefix, "is_p_label", self.identifier),
             "%s:%s: %s label p tag index 1 of id sa4\n"
-            % (info_prefix, "fig_tag_index_groups", self.identifier),
+            % (info_prefix, "tag_index_groups", self.identifier),
             "%s:%s: %s no inline-graphic tag found in p tag 2 of id sa4\n"
             % (info_prefix, "is_p_inline_graphic", self.identifier),
             "%s:%s: %s only inline-graphic tag found in p tag 3 of id sa4\n"

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,0 +1,97 @@
+import os
+import unittest
+from xml.etree import ElementTree
+from elifetools import xmlio
+from elifecleaner import configure_logging, table, LOGGER
+from tests.helpers import (
+    delete_files_in_folder,
+    read_log_file_lines,
+    sub_article_xml_fixture,
+)
+
+
+def table_sub_article_xml_fixture():
+    "generate XML test fixture for a referee-report"
+    article_type = b"referee-report"
+    sub_article_id = b"sa1"
+    front_stub_xml_string = (
+        b"<front-stub>"
+        b'<article-id pub-id-type="doi">10.7554/eLife.79713.1.sa1</article-id>'
+        b"<title-group>"
+        b"<article-title>Reviewer #1 (Public Review):</article-title>"
+        b"</title-group>"
+        b"</front-stub>"
+    )
+    body_xml_string = (
+        b"<body>"
+        b"<p>First paragraph.</p>"
+        b"<p><bold>Review table 1.</bold></p>"
+        b"<p>Table title. This is the caption for this table that describes what it contains.</p>"
+        b'<p> <inline-graphic xlink:href="elife-70493-inf1.png" /> </p>'
+        b"<p>Another paragraph with an inline graphic "
+        b'<inline-graphic xlink:href="elife-70493-inf2.jpg" /></p>'
+        b"</body>"
+    )
+    return sub_article_xml_fixture(
+        article_type, sub_article_id, front_stub_xml_string, body_xml_string
+    )
+
+
+class TestTransformTable(unittest.TestCase):
+    "tests for table.transform_table()"
+
+    def setUp(self):
+        self.identifier = "test.zip"
+        self.temp_dir = "tests/tmp"
+        self.log_file = os.path.join(self.temp_dir, "test.log")
+        self.log_handler = configure_logging(self.log_file)
+
+    def tearDown(self):
+        LOGGER.removeHandler(self.log_handler)
+        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
+
+    def test_referee_report(self):
+        "convert tags to a fig in a referee-report fixture"
+        # register XML namespaces
+        xmlio.register_xmlns()
+        xml_string = table_sub_article_xml_fixture()
+        sub_article_root = ElementTree.fromstring(xml_string)
+        root = table.transform_table(sub_article_root, self.identifier)
+
+        rough_xml_string = ElementTree.tostring(root, "utf-8")
+        self.assertTrue("<p>First paragraph.</p>" in rough_xml_string.decode("utf8"))
+        self.assertTrue(
+            '<inline-graphic xlink:href="elife-70493-inf2.jpg" />'
+            in rough_xml_string.decode("utf8")
+        )
+        self.assertTrue(
+            (
+                "<body>"
+                "<p>First paragraph.</p>"
+                '<table-wrap id="sa1table1">'
+                "<label>Review table 1.</label>"
+                "<caption>"
+                "<title>Table title.</title>"
+                "<p>This is the caption for this table that describes what it contains.</p>"
+                "</caption>"
+                '<graphic mimetype="image" mime-subtype="png" xlink:href="elife-70493-inf1.png" />'
+                "</table-wrap>"
+                "<p>Another paragraph with an inline graphic "
+                '<inline-graphic xlink:href="elife-70493-inf2.jpg" />'
+                "</p>"
+                "</body>"
+            )
+            in rough_xml_string.decode("utf8")
+        )
+        block_info_prefix = "INFO elifecleaner:block"
+        expected = [
+            '%s:%s: %s potential label "Review table 1." in p tag 1 of id sa1\n'
+            % (block_info_prefix, "is_p_label", self.identifier),
+            "%s:%s: %s label p tag index 1 of id sa1\n"
+            % (block_info_prefix, "tag_index_groups", self.identifier),
+            "%s:%s: %s no inline-graphic tag found in p tag 2 of id sa1\n"
+            % (block_info_prefix, "is_p_inline_graphic", self.identifier),
+            "%s:%s: %s only inline-graphic tag found in p tag 3 of id sa1\n"
+            % (block_info_prefix, "is_p_inline_graphic", self.identifier),
+        ]
+        self.assertEqual(read_log_file_lines(self.log_file), expected)


### PR DESCRIPTION
Added `table.py` module to find an format paragraphs into a `<table-wrap>` tag. The procedure is similar to how figures were detected, and so the `fig.py` module was refactored, moving the common functions to a new `block.py` module.

Re issue https://github.com/elifesciences/issues/issues/8383