### PR TITLE
Remove hr tags from sub article XML.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.53.0"
+__version__ = "0.54.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/sub_article.py
+++ b/elifecleaner/sub_article.py
@@ -5,7 +5,7 @@ from xml.etree.ElementTree import Element, SubElement
 from elifearticle.article import Article, Contributor, Role
 from docmaptools import parse as docmap_parse
 from jatsgenerator import build
-from elifecleaner import assessment_terms, LOGGER, parse
+from elifecleaner import assessment_terms, LOGGER, parse, utils
 
 XML_NAMESPACES = {
     "ali": "http://www.niso.org/schemas/ali/1.0/",
@@ -227,6 +227,9 @@ def format_content_json(content_json, article_object):
     for index, content in enumerate(content_json):
 
         xml_root = ElementTree.fromstring(content.get("xml"))
+        # remove hr tags
+        xml_root = utils.remove_tags(xml_root, "hr")
+
         sub_article_object = build_sub_article_object(
             article_object, xml_root, content, index
         )

--- a/elifecleaner/utils.py
+++ b/elifecleaner/utils.py
@@ -80,3 +80,11 @@ def namespace_string():
             for attrib_name, attrib_value in NAMESPACE_MAP.items()
         ]
     )
+
+
+def remove_tags(xml_root, tag_name):
+    "remove tags with name tag_name from ElementTree"
+    for tag_parent in xml_root.findall(".//%s/.." % tag_name):
+        for tag in tag_parent.findall(tag_name):
+            tag_parent.remove(tag)
+    return xml_root

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -590,6 +590,7 @@ class TestFormatContentJson(unittest.TestCase):
                     b"<li>Third <em>point</em>.</li>"
                     b"<li>Fourth point.</li>"
                     b"</ol>"
+                    b"<hr/>"
                     b"<p>About the third and fourth points.</p>"
                 ),
             },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,3 +76,21 @@ class TestOpenTag(unittest.TestCase):
         attr = {"id": "sa2fig1", "ref-type": "fig"}
         expected = '<xref id="sa2fig1" ref-type="fig">'
         self.assertEqual(utils.open_tag(tag_name, attr), expected)
+
+
+class TestRemoveTags(unittest.TestCase):
+    "tests for utils.remove_tags()"
+
+    def test_remove_tags(self):
+        xml_string = "<root><hr/></root>"
+        expected = b"<root />"
+        xml_root = ElementTree.fromstring(xml_string)
+        result = utils.remove_tags(xml_root, "hr")
+        self.assertEqual(ElementTree.tostring(result), expected)
+
+    def test_complicated_remove_tags(self):
+        xml_string = "<root><hr/><p><hr/></p></root>"
+        expected = b"<root><p /></root>"
+        xml_root = ElementTree.fromstring(xml_string)
+        result = utils.remove_tags(xml_root, "hr")
+        self.assertEqual(ElementTree.tostring(result), expected)


### PR DESCRIPTION
Remove `<hr/>` from XML taken from sub article HTML, using new function `utils.remove_tags()`.

https://github.com/elifesciences/issues/issues/8459