### PR TITLE
Use volumeIdentifier from docmap as volume.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.55.0"
+__version__ = "0.56.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -286,59 +286,23 @@ def volume_from_docmap(docmap_string, identifier=None):
             identifier,
         )
         return None
-    history_data = docmap_parse.docmap_preprint_history(d_json)
-    if not history_data:
-        LOGGER.warning(
-            "%s no history data from the docmap",
-            identifier,
-        )
-        return None
-    return volume_from_history_data(history_data, identifier)
+    preprint_data = docmap_parse.docmap_latest_preprint(d_json)
+    volume = None
+    if (
+        preprint_data
+        and preprint_data.get("partOf")
+        and preprint_data.get("partOf").get("volumeIdentifier")
+    ):
+        volume = int(preprint_data.get("partOf").get("volumeIdentifier"))
 
-
-# year of first publication, used for calculating volume
-START_YEAR = 2011
-
-
-def volume_from_history_data(history_data, identifier=None):
-    "from history data, calculate the volume from the first reviewed preprint"
-    if not history_data:
+    if not volume:
         LOGGER.warning(
-            "%s no history_data",
-            identifier,
-        )
-        return None
-    LOGGER.info(
-        "%s get first reviewed-preprint history event from the history_data", identifier
-    )
-    reviewed_preprint_event_data = None
-    for event_data in history_data:
-        if event_data.get("type") == "reviewed-preprint":
-            reviewed_preprint_event_data = event_data
-            break
-    if not reviewed_preprint_event_data:
-        LOGGER.warning(
-            "%s no reviewed-preprint event found",
-            identifier,
-        )
-        return None
-    if not reviewed_preprint_event_data.get("date"):
-        LOGGER.warning(
-            "%s first reviewed-preprint event has no published date",
+            "%s no volumeIdentifier found in the docmap",
             identifier,
         )
         return None
 
-    # get the date from the event data
-    date_struct = date_struct_from_string(reviewed_preprint_event_data.get("date"))
-    if not date_struct:
-        LOGGER.warning(
-            "%s could not parse date from the reviewed-preprint event",
-            identifier,
-        )
-        return None
-    year = date_struct[0]
-    return year - START_YEAR
+    return volume
 
 
 def date_struct_from_string(date_string):

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -343,9 +343,18 @@ def docmap_test_data(doi=None):
                             {
                                 "type": "preprint",
                                 "identifier": "85111",
-                                "versionIdentifier": "2",
+                                "versionIdentifier": "1",
                                 "license": "http://creativecommons.org/licenses/by/4.0/",
-                                "published": "2023-05-10T14:00:00+00:00",
+                                "published": "2023-01-25T14:00:00+00:00",
+                                "partOf": {
+                                    "type": "manuscript",
+                                    "doi": "10.7554/eLife.85111",
+                                    "identifier": "85111",
+                                    "subjectDisciplines": ["Neuroscience"],
+                                    "published": "2023-01-25T14:00:00+00:00",
+                                    "volumeIdentifier": "12",
+                                    "electronicArticleIdentifier": "RP85111",
+                                },
                             }
                         ]
                     },
@@ -653,14 +662,6 @@ class TestVolumeFromDocmap(unittest.TestCase):
             log_messages[0],
             ("INFO elifecleaner:prc:volume_from_docmap: " "Parse docmap json\n"),
         )
-        self.assertEqual(
-            log_messages[1],
-            (
-                "INFO elifecleaner:prc:volume_from_history_data: "
-                "%s get first reviewed-preprint history event from the history_data\n"
-            )
-            % self.identifier,
-        )
 
     def test_no_history_data(self):
         "test if no history data can be found in the docmap"
@@ -678,7 +679,7 @@ class TestVolumeFromDocmap(unittest.TestCase):
                 log_messages[-1],
                 (
                     "WARNING elifecleaner:prc:volume_from_docmap: "
-                    "%s no history data from the docmap\n"
+                    "%s no volumeIdentifier found in the docmap\n"
                 )
                 % self.identifier,
             )
@@ -700,115 +701,6 @@ class TestVolumeFromDocmap(unittest.TestCase):
                 )
                 % self.identifier,
             )
-
-
-class TestVolumeFromHistoryData(unittest.TestCase):
-    "tests for prc.volume_from_history_data()"
-
-    def setUp(self):
-        self.temp_dir = "tests/tmp"
-        self.log_file = os.path.join(self.temp_dir, "test.log")
-        self.log_handler = configure_logging(self.log_file)
-        self.identifier = "test.zip"
-
-    def tearDown(self):
-        LOGGER.removeHandler(self.log_handler)
-        delete_files_in_folder(self.temp_dir, filter_out=[".keepme"])
-
-    def test_volume_from_history_data(self):
-        "calculate the volume from history data"
-        history_data = [{"type": "reviewed-preprint", "date": "2023-01-01"}]
-        expected = 12
-        # invoke
-        volume = prc.volume_from_history_data(history_data, self.identifier)
-        # assert
-        self.assertEqual(volume, expected)
-        with open(self.log_file, "r") as open_file:
-            log_messages = open_file.readlines()
-        self.assertEqual(
-            log_messages[0],
-            (
-                "INFO elifecleaner:prc:volume_from_history_data: "
-                "%s get first reviewed-preprint history event from the history_data\n"
-            )
-            % self.identifier,
-        )
-
-    def test_no_date(self):
-        "test if there is no date to parse"
-        history_data = [{"type": "reviewed-preprint"}]
-        expected = None
-        # invoke
-        volume = prc.volume_from_history_data(history_data, self.identifier)
-        # assert
-        self.assertEqual(volume, expected)
-        with open(self.log_file, "r") as open_file:
-            log_messages = open_file.readlines()
-        self.assertEqual(
-            log_messages[-1],
-            (
-                "WARNING elifecleaner:prc:volume_from_history_data: "
-                "%s first reviewed-preprint event has no published date\n"
-            )
-            % self.identifier,
-        )
-
-    def test_bad_date(self):
-        "test if the date cannot be parsed"
-        history_data = [{"type": "reviewed-preprint", "date": "not_a_date"}]
-        expected = None
-        # invoke
-        volume = prc.volume_from_history_data(history_data, self.identifier)
-        # assert
-        self.assertEqual(volume, expected)
-        with open(self.log_file, "r") as open_file:
-            log_messages = open_file.readlines()
-        self.assertEqual(
-            log_messages[-1],
-            (
-                "WARNING elifecleaner:prc:volume_from_history_data: "
-                "%s could not parse date from the reviewed-preprint event\n"
-            )
-            % self.identifier,
-        )
-
-    def test_no_reviewed_preprint(self):
-        "test if there is no reviewed-preprint event"
-        history_data = [{"type": "preprint", "date": "2023-01-01"}]
-        expected = None
-        # invoke
-        volume = prc.volume_from_history_data(history_data, self.identifier)
-        # assert
-        self.assertEqual(volume, expected)
-        with open(self.log_file, "r") as open_file:
-            log_messages = open_file.readlines()
-        self.assertEqual(
-            log_messages[-1],
-            (
-                "WARNING elifecleaner:prc:volume_from_history_data: "
-                "%s no reviewed-preprint event found\n"
-            )
-            % self.identifier,
-        )
-
-    def test_none(self):
-        "test if history_data is None"
-        history_data = None
-        expected = None
-        # invoke
-        volume = prc.volume_from_history_data(history_data, self.identifier)
-        # assert
-        self.assertEqual(volume, expected)
-        with open(self.log_file, "r") as open_file:
-            log_messages = open_file.readlines()
-        self.assertEqual(
-            log_messages[-1],
-            (
-                "WARNING elifecleaner:prc:volume_from_history_data: "
-                "%s no history_data\n"
-            )
-            % self.identifier,
-        )
 
 
 class TestDateStructFromString(unittest.TestCase):


### PR DESCRIPTION
Article volume is present in the docmap now; use it instead of calcuating the volume from a date.

Re issue https://github.com/elifesciences/issues/issues/8440