### PR TITLE
Add published argument to prc.version_doi_from_docmap()

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.61.0"
+__version__ = "0.62.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -166,7 +166,7 @@ def elocation_id_from_docmap(docmap_string, identifier=None):
     return elocation_id
 
 
-def version_doi_from_docmap(docmap_string, identifier=None):
+def version_doi_from_docmap(docmap_string, identifier=None, published=True):
     "find the latest preprint DOI from docmap"
     doi = None
     LOGGER.info("Parse docmap json")
@@ -178,7 +178,7 @@ def version_doi_from_docmap(docmap_string, identifier=None):
         )
         return doi
     LOGGER.info("Get latest preprint data from the docmap")
-    preprint_data = docmap_parse.docmap_latest_preprint(d_json)
+    preprint_data = docmap_parse.docmap_latest_preprint(d_json, published=published)
     if not preprint_data:
         LOGGER.warning(
             "%s no preprint data was found in the docmap",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docmaptools==0.18.0
+docmaptools==0.21.0
 elifetools==0.32.0
 elifearticle==0.14.0
 jatsgenerator==0.7.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=["elifecleaner"],
     license="MIT",
     install_requires=[
-        "docmaptools>=0.18.0",
+        "docmaptools>=0.21.0",
         "elifetools",
         "elifearticle>=0.15.0",
         "jatsgenerator>=0.7.0",


### PR DESCRIPTION
`prc.version_doi_from_docmap()` accepts `published` argument with a default of `True`. This is passed to the call to `docmaptools` `parse.docmap_latest_preprint()`.

Other calls to `docmap_latest_preprint()`, which get elocation-id and volume values, are unchanged and will use the default `published=True`, since the published article versions are the best place to find these values.

The `published` argument was introduced in `docmaptools==0.21.0` so the dependency version required is bumped up here too.

Re issue https://github.com/elifesciences/issues/issues/8694