### PR TITLE
Test case for prc.version_doi_from_docmap() for finding unpublished DOI.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docmaptools==0.21.0
+docmaptools==0.22.0
 elifetools==0.32.0
 elifearticle==0.14.0
 jatsgenerator==0.7.0

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -426,6 +426,15 @@ class TestVersionDoiFromDocmap(unittest.TestCase):
         result = prc.version_doi_from_docmap(json.dumps(docmap_json), self.identifier)
         self.assertEqual(result, doi)
 
+    def test_unpublished_version_doi(self):
+        "test argument published is False"
+        doi = "10.7554/eLife.85111.2"
+        docmap_json = docmap_test_data(doi)
+        # delete the published dict key
+        del docmap_json["steps"]["_:b1"]["actions"][0]["outputs"][0]["published"]
+        result = prc.version_doi_from_docmap(json.dumps(docmap_json), self.identifier, False)
+        self.assertEqual(result, doi)
+
     def test_docmap_is_none(self):
         "test for no docmap"
         docmap_json = {}


### PR DESCRIPTION
Adding a test case to confirm finding the latest preprint version DOI is working when including unpublished version data.

Re issue https://github.com/elifesciences/issues/issues/8918