### PR TITLE
Article id tag refactoring

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.65.1"
+__version__ = "0.66.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -1,4 +1,3 @@
-import re
 import time
 from xml.etree.ElementTree import Element, SubElement
 from docmaptools import parse as docmap_parse

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -232,8 +232,24 @@ def next_version_doi(doi, identifier=None):
     return next_doi
 
 
-def add_version_doi(root, doi, identifier=None):
-    "add version article-id tag for the doi to article-meta tag"
+def add_article_id(parent, text, pub_id_type, specific_use=None):
+    "add article-id tag"
+    # add article-id tag
+    article_id_tag = Element("article-id")
+    article_id_tag.set("pub-id-type", pub_id_type)
+    if specific_use:
+        article_id_tag.set("specific-use", specific_use)
+    article_id_tag.text = text
+    # insert the new tag into the XML after the last article-id tag
+    insert_index = 1
+    for tag_index, tag in enumerate(parent.findall("*")):
+        if tag.tag == "article-id":
+            insert_index = tag_index + 1
+    parent.insert(insert_index, article_id_tag)
+
+
+def add_doi(root, doi, specific_use=None, identifier=None):
+    "add article-id tag for the doi to article-meta tag"
     article_meta_tag = root.find(".//front/article-meta")
     if article_meta_tag is None:
         LOGGER.warning(
@@ -241,18 +257,14 @@ def add_version_doi(root, doi, identifier=None):
             identifier,
         )
         return root
-    # add article-id tag
-    article_id_tag = Element("article-id")
-    article_id_tag.set("pub-id-type", "doi")
-    article_id_tag.set("specific-use", "version")
-    article_id_tag.text = doi
-    # insert the new tag into the XML after the last article-id tag
-    insert_index = 1
-    for tag_index, tag in enumerate(article_meta_tag.findall("*")):
-        if tag.tag == "article-id":
-            insert_index = tag_index + 1
-    article_meta_tag.insert(insert_index, article_id_tag)
+    # add version DOI article-id tag
+    add_article_id(article_meta_tag, doi, pub_id_type="doi", specific_use=specific_use)
     return root
+
+
+def add_version_doi(root, doi, identifier=None):
+    "add version article-id tag for the doi to article-meta tag"
+    return add_doi(root, doi, specific_use="version", identifier=identifier)
 
 
 def review_date_from_docmap(docmap_string, identifier=None):

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -558,6 +558,39 @@ class TestNextVersionDoi(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
+class TestAddArticleId(unittest.TestCase):
+    "tests for add_article_id()"
+
+    def test_add_article_id(self):
+        "test adding concept DOI article-id tag"
+        xml_string = "<article-meta />"
+        root = ElementTree.fromstring(xml_string)
+        doi = "10.7554/eLife.1234567890"
+        pub_id_type = "doi"
+        expected = (
+            "<article-meta>"
+            '<article-id pub-id-type="%s">%s</article-id>'
+            "</article-meta>"
+        ) % (pub_id_type, doi)
+        prc.add_article_id(root, doi, pub_id_type)
+        self.assertEqual(ElementTree.tostring(root).decode("utf-8"), expected)
+
+    def test_version_doi(self):
+        "test adding a version DOI article-id tag"
+        xml_string = "<article-meta />"
+        root = ElementTree.fromstring(xml_string)
+        doi = "10.7554/eLife.1234567890"
+        pub_id_type = "doi"
+        specific_use = "version"
+        expected = (
+            "<article-meta>"
+            '<article-id pub-id-type="%s" specific-use="%s">%s</article-id>'
+            "</article-meta>"
+        ) % (pub_id_type, specific_use, doi)
+        prc.add_article_id(root, doi, pub_id_type, specific_use)
+        self.assertEqual(ElementTree.tostring(root).decode("utf-8"), expected)
+
+
 class TestAddVersionDoi(unittest.TestCase):
     def setUp(self):
         self.temp_dir = "tests/tmp"
@@ -627,7 +660,7 @@ class TestAddVersionDoi(unittest.TestCase):
             self.assertEqual(
                 open_file.read(),
                 (
-                    "WARNING elifecleaner:prc:add_version_doi: "
+                    "WARNING elifecleaner:prc:add_doi: "
                     "%s article-meta tag not found\n"
                 )
                 % self.identifier,

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -432,7 +432,9 @@ class TestVersionDoiFromDocmap(unittest.TestCase):
         docmap_json = docmap_test_data(doi)
         # delete the published dict key
         del docmap_json["steps"]["_:b1"]["actions"][0]["outputs"][0]["published"]
-        result = prc.version_doi_from_docmap(json.dumps(docmap_json), self.identifier, False)
+        result = prc.version_doi_from_docmap(
+            json.dumps(docmap_json), self.identifier, False
+        )
         self.assertEqual(result, doi)
 
     def test_docmap_is_none(self):
@@ -659,10 +661,7 @@ class TestAddVersionDoi(unittest.TestCase):
         with open(self.log_file, "r") as open_file:
             self.assertEqual(
                 open_file.read(),
-                (
-                    "WARNING elifecleaner:prc:add_doi: "
-                    "%s article-meta tag not found\n"
-                )
+                ("WARNING elifecleaner:prc:add_doi: " "%s article-meta tag not found\n")
                 % self.identifier,
             )
 


### PR DESCRIPTION
Refactor `prc.add_version_doi()` to be more general purpose, retaining backwards compatibility.