### PR TITLE
Change how DOI is generated in build_sub_article_object()

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.68.0"
+__version__ = "0.69.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docmaptools==0.23.0
+docmaptools==0.24.0
 elifetools==0.32.0
 elifearticle==0.14.0
 jatsgenerator==0.7.0


### PR DESCRIPTION
When generating `<sub-article>` tags and data for them, they can either have a DOI generated for them, or the DOI is copied from docmap data. These changes clarify how an `Article` is only used as an argument when DOIs must be generated, otherwise it can be `None`. Also, only if an `Article` is supplied will author contributors be copied from it to particiular sub-articles.