### PR TITLE
Pub history refactoring and enhancements.

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.70.0"
+__version__ = "0.71.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/prc.py
+++ b/elifecleaner/prc.py
@@ -2,7 +2,6 @@ import time
 from xml.etree.ElementTree import Element, SubElement
 from docmaptools import parse as docmap_parse
 from jatsgenerator import build as jats_build
-from elifetools.utils import doi_to_doi_uri
 from elifecleaner import LOGGER
 
 # for each ISSN, values for journal-id-type tag text
@@ -418,69 +417,4 @@ def add_history_date(root, date_type, date_struct, identifier=None):
         date_tag.set("date-type", date_type)
         date_tag.set("iso-8601-date", time.strftime("%Y-%m-%d", date_struct))
     jats_build.set_dmy(date_tag, date_struct)
-    return root
-
-
-EVENT_DESC_PREPRINT = "This manuscript was published as a preprint."
-EVENT_DESC_REVIEWED_PREPRINT = "This manuscript was published as a reviewed preprint."
-EVENT_DESC_REVISED_PREPRINT = "The reviewed preprint was revised."
-
-
-def add_pub_history(root, history_data, identifier=None):
-    "add the pub-history tag and add event data to it"
-    if not history_data:
-        return root
-    article_meta_tag = root.find(".//front/article-meta")
-    if article_meta_tag is None:
-        LOGGER.warning(
-            "%s article-meta tag not found",
-            identifier,
-        )
-        return root
-    # look for an existing pub-history tag
-    pub_history_tag = article_meta_tag.find("./pub-history")
-    # if no pub-history tag, add one
-    if pub_history_tag is None:
-        # insert the new tag into the XML after the history or elocation-id tag
-        insert_index = 1
-        for tag_index, tag in enumerate(article_meta_tag.findall("*")):
-            if tag.tag in "history":
-                insert_index = tag_index + 1
-                break
-            if tag.tag == "elocation-id":
-                insert_index = tag_index + 1
-        pub_history_tag = Element("pub-history")
-        article_meta_tag.insert(insert_index, pub_history_tag)
-    # add event tags to the pub-history tag
-    added_reviewed_preprint = None
-    for history_event_data in history_data:
-        event_tag = SubElement(pub_history_tag, "event")
-        if history_event_data.get("type"):
-            if history_event_data.get("type") == "preprint":
-                event_desc_tag = SubElement(event_tag, "event-desc")
-                event_desc_tag.text = EVENT_DESC_PREPRINT
-            elif history_event_data.get("type") == "reviewed-preprint":
-                event_desc_tag = SubElement(event_tag, "event-desc")
-                if added_reviewed_preprint:
-                    # already added one reviewed-preprint
-                    event_desc_tag.text = EVENT_DESC_REVISED_PREPRINT
-                else:
-                    # adding the first reviewed-preprint
-                    event_desc_tag.text = EVENT_DESC_REVIEWED_PREPRINT
-                added_reviewed_preprint = True
-        if history_event_data.get("date"):
-            date_struct = date_struct_from_string(history_event_data.get("date"))
-            date_tag = SubElement(event_tag, "date")
-            if history_event_data.get("type"):
-                date_tag.set("date-type", history_event_data.get("type"))
-            jats_build.set_dmy(date_tag, date_struct)
-            date_tag.set("iso-8601-date", time.strftime("%Y-%m-%d", date_struct))
-            if history_event_data.get("doi"):
-                self_uri_tag = SubElement(event_tag, "self-uri")
-                if history_event_data.get("type"):
-                    self_uri_tag.set("content-type", history_event_data.get("type"))
-                self_uri_tag.set(
-                    "{http://www.w3.org/1999/xlink}href",
-                    doi_to_doi_uri(history_event_data.get("doi")),
-                )
     return root

--- a/elifecleaner/pub_history.py
+++ b/elifecleaner/pub_history.py
@@ -1,0 +1,220 @@
+import time
+from xml.etree.ElementTree import Element, SubElement
+from docmaptools import parse as docmap_parse
+from jatsgenerator import build as jats_build
+from elifetools.utils import doi_to_doi_uri
+from elifecleaner import sub_article, LOGGER
+from elifecleaner.prc import date_struct_from_string
+
+
+def find_pub_history_tag(root, identifier=None):
+    "find pub-history tag in the article-meta tag"
+    article_meta_tag = root.find(".//front/article-meta")
+    if article_meta_tag is None:
+        LOGGER.warning(
+            "%s article-meta tag not found",
+            identifier,
+        )
+        return None
+    # look for an existing pub-history tag
+    pub_history_tag = article_meta_tag.find("./pub-history")
+    # if no pub-history tag, add one
+    if pub_history_tag is None:
+        # insert the new tag into the XML after the history or elocation-id tag
+        insert_index = 1
+        for tag_index, tag in enumerate(article_meta_tag.findall("*")):
+            if tag.tag in "history":
+                insert_index = tag_index + 1
+                break
+            if tag.tag == "elocation-id":
+                insert_index = tag_index + 1
+        pub_history_tag = Element("pub-history")
+        article_meta_tag.insert(insert_index, pub_history_tag)
+    return pub_history_tag
+
+
+def add_self_uri_tag(parent, article_type, uri, title):
+    "add self-uri tag for each peer review in event tag"
+    self_uri_tag = SubElement(parent, "self-uri")
+    if article_type:
+        self_uri_tag.set("content-type", article_type)
+    self_uri_tag.set(
+        "{http://www.w3.org/1999/xlink}href",
+        uri,
+    )
+    self_uri_tag.text = str(title)
+
+
+def add_history_event_tag(parent, event_data):
+    "add event tag to pub-history"
+    event_tag = SubElement(parent, "event")
+    if event_data.get("event_desc"):
+        event_desc_tag = SubElement(event_tag, "event-desc")
+        event_desc_tag.text = event_data.get("event_desc")
+    if event_data.get("date"):
+        date_struct = date_struct_from_string(event_data.get("date"))
+        date_tag = SubElement(event_tag, "date")
+        if event_data.get("type"):
+            date_tag.set("date-type", event_data.get("type"))
+        jats_build.set_dmy(date_tag, date_struct)
+        date_tag.set("iso-8601-date", time.strftime("%Y-%m-%d", date_struct))
+        if event_data.get("doi"):
+            self_uri_tag = SubElement(event_tag, "self-uri")
+            if event_data.get("type"):
+                self_uri_tag.set("content-type", event_data.get("type"))
+            self_uri_tag.set(
+                "{http://www.w3.org/1999/xlink}href",
+                doi_to_doi_uri(event_data.get("doi")),
+            )
+    if event_data.get("self_uri_list"):
+        for self_uri_data in event_data.get("self_uri_list"):
+            add_self_uri_tag(
+                event_tag,
+                self_uri_data.get("content_type"),
+                self_uri_data.get("uri"),
+                self_uri_data.get("title"),
+            )
+
+
+EVENT_DESC_PREPRINT = "This manuscript was published as a preprint."
+EVENT_DESC_REVIEWED_PREPRINT = "This manuscript was published as a reviewed preprint."
+EVENT_DESC_REVISED_PREPRINT = "The reviewed preprint was revised."
+
+MECA_EVENT_DESC_PREPRINT = "Preprint posted"
+MECA_EVENT_DESC_REVIEWED_PREPRINT = "Reviewed preprint"
+MECA_EVENT_DESC_REVISED_PREPRINT = "Reviewed preprint"
+
+
+def preprint_event_desc(style):
+    "generate event event-desc tag text for a preprint history event"
+    event_description = None
+    if style == "accepted":
+        event_description = EVENT_DESC_PREPRINT
+    elif style == "meca":
+        event_description = MECA_EVENT_DESC_PREPRINT
+    return event_description
+
+
+def reviewed_preprint_event_desc(style, first_review_event, version):
+    "generate event event-desc tag text for a reviewed preprint history event"
+    event_description = None
+    extra = ""
+    if style == "meca" and version:
+        extra = " v%s" % version
+    if first_review_event:
+        # adding the first reviewed-preprint
+        if style == "accepted":
+            event_description = "%s%s" % (
+                EVENT_DESC_REVIEWED_PREPRINT,
+                extra,
+            )
+        elif style == "meca":
+            event_description = "%s%s" % (
+                MECA_EVENT_DESC_REVIEWED_PREPRINT,
+                extra,
+            )
+    else:
+        # already added one reviewed-preprint
+        if style == "accepted":
+            event_description = "%s%s" % (
+                EVENT_DESC_REVISED_PREPRINT,
+                extra,
+            )
+        elif style == "meca":
+            event_description = "%s%s" % (
+                MECA_EVENT_DESC_REVISED_PREPRINT,
+                extra,
+            )
+    return event_description
+
+
+def history_event_self_uri_list(docmap_string, version_doi):
+    "a list of self-uri tag data for a history event"
+    self_uri_list = []
+    d_json = docmap_parse.docmap_json(docmap_string)
+    step_map = docmap_parse.preprint_version_doi_step_map(d_json)
+    if step_map.get(version_doi):
+        generate_dois = False
+        data = sub_article.sub_article_data(
+            docmap_string,
+            version_doi=version_doi,
+            generate_dois=generate_dois,
+        )
+        for data_item in data:
+            self_uri_data = {}
+            if data_item.get("article").article_type:
+                self_uri_data["content_type"] = data_item.get("article").article_type
+            self_uri_data["uri"] = doi_to_doi_uri(data_item.get("article").doi)
+            self_uri_data["title"] = str(data_item.get("article").title)
+            self_uri_list.append(self_uri_data)
+    return self_uri_list
+
+
+def collect_history_event_data(
+    history_data, style, docmap_string=None, add_self_uri=False
+):
+    "populate a list of history event data"
+    history_event_data = []
+    if not history_data:
+        return history_event_data
+    first_review_event = True
+    for data in history_data:
+        event_data = {}
+        event_data["type"] = data.get("type")
+        event_data["date"] = data.get("date")
+        event_data["doi"] = data.get("doi")
+        event_data["versionIdentifier"] = data.get("versionIdentifier")
+        # event description
+        if event_data.get("type") == "preprint":
+            event_data["event_desc"] = preprint_event_desc(style)
+        elif event_data.get("type") == "reviewed-preprint":
+            event_data["event_desc"] = reviewed_preprint_event_desc(
+                style, first_review_event, event_data.get("versionIdentifier")
+            )
+            first_review_event = False
+        # self-uri values
+        if add_self_uri and docmap_string:
+            event_data["self_uri_list"] = history_event_self_uri_list(
+                docmap_string, version_doi=event_data.get("doi")
+            )
+        # append the event data to the list
+        history_event_data.append(event_data)
+    return history_event_data
+
+
+def add_pub_history_tag(root, history_event_data, identifier=None):
+    "set event data in pub-history tag"
+    if not history_event_data:
+        return root
+    pub_history_tag = find_pub_history_tag(root, identifier)
+    if pub_history_tag is None:
+        return root
+    # add event tags to the pub-history tag
+    for event_data in history_event_data:
+        add_history_event_tag(
+            pub_history_tag,
+            event_data,
+        )
+    return root
+
+
+def add_pub_history(root, history_data, docmap_string=None, identifier=None):
+    "add the pub-history tag and add event data to it"
+    style = "accepted"
+    add_self_uri = False
+    # collect history event data
+    history_event_data = collect_history_event_data(
+        history_data, style, docmap_string, add_self_uri
+    )
+    return add_pub_history_tag(root, history_event_data, identifier)
+
+
+def add_pub_history_meca(root, history_data, docmap_string=None, identifier=None):
+    "add the MECA style pub-history tag and add event data to it"
+    style = "meca"
+    add_self_uri = True
+    # collect history event data
+    history_event_data = collect_history_event_data(
+        history_data, style, docmap_string, add_self_uri
+    )
+    return add_pub_history_tag(root, history_event_data, identifier)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -61,3 +61,22 @@ def sub_article_xml_fixture(
         b'article-type="%s" id="%s">%s%s</sub-article>'
         % (article_type, sub_article_id, front_stub_xml_string, body_xml_string)
     )
+
+
+class FakeRequest:
+    def __init__(self):
+        self.headers = {}
+        self.body = None
+
+
+class FakeResponse:
+    def __init__(self, status_code, response_json=None, text="", content=None):
+        self.status_code = status_code
+        self.response_json = response_json
+        self.content = content
+        self.text = text
+        self.request = FakeRequest()
+        self.headers = {}
+
+    def json(self):
+        return self.response_json

--- a/tests/test_prc.py
+++ b/tests/test_prc.py
@@ -3,9 +3,9 @@ import time
 import unittest
 from xml.etree import ElementTree
 import json
-from elifetools import xmlio
 from elifecleaner import LOGGER, configure_logging, prc
 from tests.helpers import delete_files_in_folder
+
 
 # elife ISSN example of non-PRC journal-id tag values
 NON_PRC_XML = (
@@ -84,7 +84,6 @@ class TestTransformJournalIdTags(unittest.TestCase):
         # populate an ElementTree
         identifier = "test.zip"
         xml_string = PRC_XML
-        expected = bytes(NON_PRC_XML, encoding="utf-8")
         root = ElementTree.fromstring(xml_string)
         # invoke the function
         root_output = prc.transform_journal_id_tags(root, identifier)
@@ -1205,132 +1204,4 @@ class TestAddHistoryDate(unittest.TestCase):
         root_output = prc.add_history_date(
             root, self.date_type, self.date_struct, self.identifier
         )
-        self.assertEqual(ElementTree.tostring(root_output), expected)
-
-
-class TestAddPubHistory(unittest.TestCase):
-    "tests for prc.add_pub_history()"
-
-    def setUp(self):
-        # register XML namespaces
-        xmlio.register_xmlns()
-
-        self.xml_string_template = '<article xmlns:xlink="http://www.w3.org/1999/xlink"><front><article-meta>%s</article-meta></front></article>'
-        self.history_data = [
-            {
-                "type": "preprint",
-                "date": "2022-11-22",
-                "doi": "10.1101/2022.11.08.515698",
-                "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
-                "versionIdentifier": "2",
-                "published": "2022-11-22",
-                "content": [
-                    {
-                        "type": "computer-file",
-                        "url": "s3://transfers-elife/biorxiv_Current_Content/November_2022/23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca",
-                    }
-                ],
-            },
-            {
-                "type": "reviewed-preprint",
-                "date": "2023-01-25T14:00:00+00:00",
-                "identifier": "85111",
-                "doi": "10.7554/eLife.85111.1",
-                "versionIdentifier": "1",
-                "license": "http://creativecommons.org/licenses/by/4.0/",
-                "published": "2023-01-25T14:00:00+00:00",
-            },
-            {
-                "type": "reviewed-preprint",
-                "date": "2023-05-10T14:00:00+00:00",
-                "identifier": "85111",
-                "doi": "10.7554/eLife.85111.2",
-                "versionIdentifier": "2",
-                "license": "http://creativecommons.org/licenses/by/4.0/",
-                "published": "2023-05-10T14:00:00+00:00",
-            },
-        ]
-        self.identifier = "test.zip"
-        # expected history XML string for when using the input values
-        self.xml_output = (
-            "<pub-history>"
-            "<event>"
-            "<event-desc>This manuscript was published as a preprint.</event-desc>"
-            '<date date-type="preprint" iso-8601-date="2022-11-22">'
-            "<day>22</day>"
-            "<month>11</month>"
-            "<year>2022</year>"
-            "</date>"
-            '<self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2022.11.08.515698" />'
-            "</event>"
-            "<event>"
-            "<event-desc>This manuscript was published as a reviewed preprint.</event-desc>"
-            '<date date-type="reviewed-preprint" iso-8601-date="2023-01-25">'
-            "<day>25</day>"
-            "<month>01</month>"
-            "<year>2023</year>"
-            "</date>"
-            '<self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.85111.1" />'
-            "</event>"
-            "<event>"
-            "<event-desc>The reviewed preprint was revised.</event-desc>"
-            '<date date-type="reviewed-preprint" iso-8601-date="2023-05-10">'
-            "<day>10</day>"
-            "<month>05</month>"
-            "<year>2023</year>"
-            "</date>"
-            '<self-uri content-type="reviewed-preprint" xlink:href="https://doi.org/10.7554/eLife.85111.2" />'
-            "</event>"
-            "</pub-history>"
-        )
-
-    def test_add_pub_history(self):
-        "test adding to an existing pub-history tag"
-        xml_string = self.xml_string_template % "<pub-history />"
-        expected = bytes(self.xml_string_template % self.xml_output, encoding="utf-8")
-        root = ElementTree.fromstring(xml_string)
-        root_output = prc.add_pub_history(root, self.history_data, self.identifier)
-        print(ElementTree.tostring(root_output))
-        self.assertEqual(ElementTree.tostring(root_output), expected)
-
-    def test_no_data(self):
-        "test for if there is no data to be added"
-        # use xlink:href in the sample and the xmlns is kept in the output
-        xml_string = (
-            self.xml_string_template % '<ext-link xlink:href="https://example.org" />'
-        )
-        history_data = None
-        expected = bytes(xml_string, encoding="utf-8")
-        root = ElementTree.fromstring(xml_string)
-        root_output = prc.add_pub_history(root, history_data, self.identifier)
-        self.assertEqual(ElementTree.tostring(root_output), expected)
-
-    def test_after_history_tag(self):
-        "test adding a pub-history tag after an existing history tag"
-        xml_string = self.xml_string_template % "<history />"
-        expected = bytes(
-            self.xml_string_template % ("<history />" + self.xml_output),
-            encoding="utf-8",
-        )
-        root = ElementTree.fromstring(xml_string)
-        root_output = prc.add_pub_history(root, self.history_data, self.identifier)
-        self.assertEqual(ElementTree.tostring(root_output), expected)
-
-    def test_elocation_id_tag(self):
-        "test pub-history tag should be added after the elocation-id tag"
-        xml_string = self.xml_string_template % "<elocation-id />"
-        expected = bytes(
-            self.xml_string_template % ("<elocation-id />" + self.xml_output),
-            encoding="utf-8",
-        )
-        root = ElementTree.fromstring(xml_string)
-        root_output = prc.add_pub_history(root, self.history_data, self.identifier)
-        self.assertEqual(ElementTree.tostring(root_output), expected)
-
-    def test_no_article_meta(self):
-        "test if there is no article-meta tag"
-        xml_string = "<article />"
-        expected = b"<article />"
-        root = ElementTree.fromstring(xml_string)
-        root_output = prc.add_pub_history(root, self.history_data, self.identifier)
         self.assertEqual(ElementTree.tostring(root_output), expected)

--- a/tests/test_pub_history.py
+++ b/tests/test_pub_history.py
@@ -1,0 +1,954 @@
+import unittest
+from xml.etree import ElementTree
+from mock import patch
+from elifetools import xmlio
+from elifecleaner import pub_history
+from tests.helpers import read_fixture
+
+SCIETY_DATA = {
+    "https://sciety.org/evaluations/hypothesis:6wCSiENREe-fsV9XrL_PJA/content": (
+        b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Author response:"
+    ),
+    "https://sciety.org/evaluations/hypothesis:63fsPkNREe-RHzPeZyV9vQ/content": (
+        b"<p><strong>%s</strong></p>\n"
+        b"<p>The ....</p>\n" % b"Reviewer #3 (Public Review):"
+    ),
+    "https://sciety.org/evaluations/hypothesis:6-3XyENREe-rjbPoWNzSvw/content": (
+        b"<p><strong>%s</strong></p>\n"
+        b"<p>The ....</p>\n" % b"Reviewer #2 (Public Review):"
+    ),
+    "https://sciety.org/evaluations/hypothesis:7GBk0kNREe-LnVes3-n_9Q/content": (
+        b"<p><strong>%s</strong></p>\n"
+        b"<p>The ....</p>\n" % b"Reviewer #1 (Public Review):"
+    ),
+    "https://sciety.org/evaluations/hypothesis:7NzOvkNREe-fshsElWV5TQ/content": (
+        b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"eLife assessment"
+    ),
+}
+
+
+def mock_get_web_content(
+    url=None,
+):
+    "return a content containing the response data based on the URL"
+    if url and url in SCIETY_DATA:
+        return SCIETY_DATA.get(url)
+    # default
+    return b"<p><strong>%s</strong></p>\n" b"<p>The ....</p>\n" % b"Title"
+
+
+class TestFindPubHistoryTag(unittest.TestCase):
+    "tests for find_pub_history_tag()"
+
+    def test_find_pub_history_tag(self):
+        "test finding pub-history tag from XML"
+        xml_string = (
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            "<pub-history />"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        identifier = "identifier"
+        expected = "<pub-history />"
+        # invoke
+        result = pub_history.find_pub_history_tag(root, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf-8"), expected)
+
+    def test_history_tag(self):
+        "test if history tag is in XML"
+        xml_string = (
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            "<history />"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        identifier = "identifier"
+        expected = "<pub-history />"
+        # invoke
+        result = pub_history.find_pub_history_tag(root, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf-8"), expected)
+
+    def test_elocation_id_tag(self):
+        "test if elocation-id tag is in XML"
+        xml_string = (
+            "<article>"
+            "<front><article-meta><elocation-id /></article-meta></front></article>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        identifier = "identifier"
+        expected = "<pub-history />"
+        # invoke
+        result = pub_history.find_pub_history_tag(root, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf-8"), expected)
+
+    def test_no_article_meta(self):
+        "test no article-meta tag in XML"
+        xml_string = "<article />"
+        root = ElementTree.fromstring(xml_string)
+        identifier = "identifier"
+        expected = None
+        # invoke
+        result = pub_history.find_pub_history_tag(root, identifier)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestAddSelfUriTag(unittest.TestCase):
+    "tests for add_self_uri_tag()"
+
+    def test_add_self_uri_tag(self):
+        "test adding self-uri tag"
+        xmlio.register_xmlns()
+        parent = ElementTree.fromstring("<root />")
+        article_type = "preprint"
+        uri = "https://example.org/"
+        title = "A self URI"
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<self-uri content-type="preprint" xlink:href="https://example.org/">'
+            "A self URI"
+            "</self-uri>"
+            "</root>"
+        )
+        # invoke
+        pub_history.add_self_uri_tag(parent, article_type, uri, title)
+        # assert
+        self.assertEqual(ElementTree.tostring(parent).decode("utf-8"), expected)
+
+
+class TestAddHistoryEventTag(unittest.TestCase):
+    "tests for add_history_event_tag()"
+
+    def test_add_history_event_tag(self):
+        "test adding event tag with examples of all content"
+        xmlio.register_xmlns()
+        parent = ElementTree.fromstring("<root />")
+        event_data = {
+            "event_desc": "Preprint posted",
+            "type": "preprint",
+            "doi": "https://example.org/doi",
+            "date": "2024-10-21",
+            "self_uri_list": [
+                {
+                    "content_type": "editor-report",
+                    "uri": "https://example.org/",
+                    "title": "eLife assessment",
+                }
+            ],
+        }
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<event>"
+            "<event-desc>Preprint posted</event-desc>"
+            '<date date-type="preprint" iso-8601-date="2024-10-21">'
+            "<day>21</day>"
+            "<month>10</month>"
+            "<year>2024</year>"
+            "</date>"
+            '<self-uri content-type="preprint"'
+            ' xlink:href="https://doi.org/https://example.org/doi" />'
+            '<self-uri content-type="editor-report"'
+            ' xlink:href="https://example.org/">eLife assessment</self-uri>'
+            "</event>"
+            "</root>"
+        )
+        # invoke
+        pub_history.add_history_event_tag(parent, event_data)
+        # assert
+        self.assertEqual(ElementTree.tostring(parent).decode("utf-8"), expected)
+
+
+class TestPreprintEventDesc(unittest.TestCase):
+    "tests for preprint_event_desc()"
+
+    def test_accepted_style(self):
+        "test accepted style"
+        style = "accepted"
+        expected = "This manuscript was published as a preprint."
+        # invoke
+        result = pub_history.preprint_event_desc(style)
+        # assert
+        self.assertEqual(result, expected)
+
+    def test_meca_style(self):
+        "test meca style"
+        style = "meca"
+        expected = "Preprint posted"
+        # invoke
+        result = pub_history.preprint_event_desc(style)
+        # assert
+        self.assertEqual(result, expected)
+
+    def test_none(self):
+        "test style None"
+        style = None
+        expected = None
+        # invoke
+        result = pub_history.preprint_event_desc(style)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestReviewedPreprintEventDesc(unittest.TestCase):
+    "tests for reviewed_preprint_event_desc()"
+
+    def test_accepted_style_first_1(self):
+        "test accepted style version 1 first event"
+        style = "accepted"
+        first_review_event = True
+        version = 1
+        expected = "This manuscript was published as a reviewed preprint."
+        # invoke
+        result = pub_history.reviewed_preprint_event_desc(
+            style, first_review_event, version
+        )
+        # assert
+        self.assertEqual(result, expected)
+
+    def test_accepted_style_not_first_2(self):
+        "test accepted style version 2 not first event"
+        style = "accepted"
+        first_review_event = False
+        version = 2
+        expected = "The reviewed preprint was revised."
+        # invoke
+        result = pub_history.reviewed_preprint_event_desc(
+            style, first_review_event, version
+        )
+        # assert
+        self.assertEqual(result, expected)
+
+    def test_meca_style_first_1(self):
+        "test meca style version 1 first event"
+        style = "meca"
+        first_review_event = True
+        version = 1
+        expected = "Reviewed preprint v1"
+        # invoke
+        result = pub_history.reviewed_preprint_event_desc(
+            style, first_review_event, version
+        )
+        # assert
+        self.assertEqual(result, expected)
+
+    def test_meca_style_not_first_2(self):
+        "test meca style version 1 first event"
+        style = "meca"
+        first_review_event = False
+        version = 2
+        expected = "Reviewed preprint v2"
+        # invoke
+        result = pub_history.reviewed_preprint_event_desc(
+            style, first_review_event, version
+        )
+        # assert
+        self.assertEqual(result, expected)
+
+    def test_none(self):
+        "test style None"
+        style = None
+        first_review_event = None
+        version = None
+        expected = None
+        # invoke
+        result = pub_history.reviewed_preprint_event_desc(
+            style, first_review_event, version
+        )
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestHistoryEventSelfUriList(unittest.TestCase):
+    "tests for history_event_self_uri_list()"
+
+    @patch("docmaptools.parse.get_web_content")
+    def test_self_uri_list(self, fake_get):
+        "test get self-uri data from docmap"
+        fake_get.side_effect = mock_get_web_content
+        docmap_string = read_fixture("99854.json", mode="r")
+        version_doi = "10.7554/eLife.99854.1"
+        expected = [
+            {
+                "content_type": "editor-report",
+                "uri": "https://doi.org/10.7554/eLife.99854.1.sa4",
+                "title": "eLife assessment",
+            },
+            {
+                "content_type": "referee-report",
+                "uri": "https://doi.org/10.7554/eLife.99854.1.sa3",
+                "title": "Reviewer #1 (Public Review):",
+            },
+            {
+                "content_type": "referee-report",
+                "uri": "https://doi.org/10.7554/eLife.99854.1.sa2",
+                "title": "Reviewer #2 (Public Review):",
+            },
+            {
+                "content_type": "referee-report",
+                "uri": "https://doi.org/10.7554/eLife.99854.1.sa1",
+                "title": "Reviewer #3 (Public Review):",
+            },
+            {
+                "content_type": "author-comment",
+                "uri": "https://doi.org/10.7554/eLife.99854.1.sa0",
+                "title": "Author response:",
+            },
+        ]
+        # invoke
+        result = pub_history.history_event_self_uri_list(docmap_string, version_doi)
+        # assert
+        self.assertEqual(result, expected)
+
+
+HISTORY_DATA_99854 = [
+    {
+        "type": "preprint",
+        "date": "2024-04-27",
+        "doi": "10.1101/2024.04.25.591185",
+        "url": "https://www.biorxiv.org/content/10.1101/2024.04.25.591185v1",
+        "versionIdentifier": "1",
+        "published": "2024-04-27",
+        "content": [
+            {
+                "type": "computer-file",
+                "url": "s3://prod-elife-epp-meca/99854-v1-meca.zip",
+            }
+        ],
+    },
+    {
+        "type": "reviewed-preprint",
+        "date": "2024-07-17T14:00:00+00:00",
+        "identifier": "99854",
+        "doi": "10.7554/eLife.99854.1",
+        "versionIdentifier": "1",
+        "license": "http://creativecommons.org/licenses/by/4.0/",
+        "published": "2024-07-17T14:00:00+00:00",
+        "partOf": {
+            "type": "manuscript",
+            "doi": "10.7554/eLife.99854",
+            "identifier": "99854",
+            "subjectDisciplines": ["Structural Biology and Molecular Biophysics"],
+            "published": "2024-07-17T14:00:00+00:00",
+            "volumeIdentifier": "13",
+            "electronicArticleIdentifier": "RP99854",
+            "complement": [],
+        },
+    },
+    {
+        "type": "reviewed-preprint",
+        "date": "2024-07-18T14:00:00+00:00",
+        "identifier": "99854",
+        "doi": "10.7554/eLife.99854.2",
+        "versionIdentifier": "2",
+        "license": "http://creativecommons.org/licenses/by/4.0/",
+        "published": "2024-07-18T14:00:00+00:00",
+        "partOf": {
+            "type": "manuscript",
+            "doi": "10.7554/eLife.99854",
+            "identifier": "99854",
+            "subjectDisciplines": ["Structural Biology and Molecular Biophysics"],
+            "published": "2024-07-18T14:00:00+00:00",
+            "volumeIdentifier": "13",
+            "electronicArticleIdentifier": "RP99854",
+            "complement": [],
+        },
+    },
+]
+
+
+class TestCollectHistoryEventData(unittest.TestCase):
+    "tests for collect_history_event_data()"
+
+    def test_accepted(self):
+        "test collecting history data for accepted style"
+        history_data = [
+            {
+                "type": "preprint",
+                "date": "2022-11-22",
+                "doi": "10.1101/2022.11.08.515698",
+                "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
+                "versionIdentifier": "2",
+                "published": "2022-11-22",
+                "content": [
+                    {
+                        "type": "computer-file",
+                        "url": (
+                            "s3://transfers-elife/biorxiv_Current_Content/November_2022/"
+                            "23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca"
+                        ),
+                    }
+                ],
+            },
+        ]
+        style = "accepted"
+        docmap_string = read_fixture("99854.json", mode="r")
+        add_self_uri = False
+        expected = [
+            {
+                "type": "preprint",
+                "date": "2022-11-22",
+                "doi": "10.1101/2022.11.08.515698",
+                "versionIdentifier": "2",
+                "event_desc": "This manuscript was published as a preprint.",
+            }
+        ]
+        # invoke
+        result = pub_history.collect_history_event_data(
+            history_data, style, docmap_string, add_self_uri
+        )
+        # assert
+        self.assertEqual(len(result), 1)
+        self.assertDictEqual(result[0], expected[0])
+
+    @patch("docmaptools.parse.get_web_content")
+    def test_meca(self, fake_get):
+        "test collecting history data for meca style including self-uri data"
+        fake_get.side_effect = mock_get_web_content
+        style = "meca"
+        docmap_string = read_fixture("99854.json", mode="r")
+        add_self_uri = True
+        expected = [
+            {
+                "type": "preprint",
+                "date": "2024-04-27",
+                "doi": "10.1101/2024.04.25.591185",
+                "versionIdentifier": "1",
+                "event_desc": "Preprint posted",
+                "self_uri_list": [],
+            },
+            {
+                "type": "reviewed-preprint",
+                "date": "2024-07-17T14:00:00+00:00",
+                "doi": "10.7554/eLife.99854.1",
+                "versionIdentifier": "1",
+                "event_desc": "Reviewed preprint v1",
+                "self_uri_list": [
+                    {
+                        "content_type": "editor-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa4",
+                        "title": "eLife assessment",
+                    },
+                    {
+                        "content_type": "referee-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa3",
+                        "title": "Reviewer #1 (Public Review):",
+                    },
+                    {
+                        "content_type": "referee-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa2",
+                        "title": "Reviewer #2 (Public Review):",
+                    },
+                    {
+                        "content_type": "referee-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa1",
+                        "title": "Reviewer #3 (Public Review):",
+                    },
+                    {
+                        "content_type": "author-comment",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa0",
+                        "title": "Author response:",
+                    },
+                ],
+            },
+        ]
+        # invoke
+        result = pub_history.collect_history_event_data(
+            HISTORY_DATA_99854[0:2], style, docmap_string, add_self_uri
+        )
+        # assert
+        self.assertEqual(len(result), 2)
+        self.assertDictEqual(result[0], expected[0])
+        self.assertDictEqual(result[1], expected[1])
+
+    def test_no_history_data(self):
+        "test if no history data supplied"
+        history_data = []
+        expected = []
+        # invoke
+        result = pub_history.collect_history_event_data(history_data, None, None, None)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestAddPubHistoryTag(unittest.TestCase):
+    "tests for add_pub_history_tag()"
+
+    def test_add_pub_history_tag(self):
+        "test adding pub-history tag"
+        root = ElementTree.fromstring(
+            "<article><front><article-meta /></front></article>"
+        )
+        history_event_data = [
+            {
+                "type": "preprint",
+                "date": "2022-11-22",
+                "doi": "10.1101/2022.11.08.515698",
+                "versionIdentifier": "2",
+                "event_desc": "Preprint posted",
+                "self_uri_list": [],
+            },
+            {
+                "type": "reviewed-preprint",
+                "date": "2024-07-17T14:00:00+00:00",
+                "doi": "10.7554/eLife.99854.1",
+                "versionIdentifier": "1",
+                "event_desc": "Reviewed preprint v1",
+                "self_uri_list": [
+                    {
+                        "content_type": "editor-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa4",
+                        "title": "eLife assessment",
+                    },
+                    {
+                        "content_type": "referee-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa3",
+                        "title": "Reviewer #1 (Public Review):",
+                    },
+                    {
+                        "content_type": "referee-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa2",
+                        "title": "Reviewer #2 (Public Review):",
+                    },
+                    {
+                        "content_type": "referee-report",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa1",
+                        "title": "Reviewer #3 (Public Review):",
+                    },
+                    {
+                        "content_type": "author-comment",
+                        "uri": "https://doi.org/10.7554/eLife.99854.1.sa0",
+                        "title": "Author response:",
+                    },
+                ],
+            },
+        ]
+        identifier = "identifier"
+        expected = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<front>"
+            "<article-meta>"
+            "<pub-history>"
+            "<event>"
+            "<event-desc>Preprint posted</event-desc>"
+            '<date date-type="preprint" iso-8601-date="2022-11-22">'
+            "<day>22</day>"
+            "<month>11</month>"
+            "<year>2022</year>"
+            "</date>"
+            '<self-uri content-type="preprint"'
+            ' xlink:href="https://doi.org/10.1101/2022.11.08.515698" />'
+            "</event>"
+            "<event>"
+            "<event-desc>Reviewed preprint v1</event-desc>"
+            '<date date-type="reviewed-preprint" iso-8601-date="2024-07-17">'
+            "<day>17</day>"
+            "<month>07</month>"
+            "<year>2024</year>"
+            "</date>"
+            '<self-uri content-type="reviewed-preprint"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1" />'
+            '<self-uri content-type="editor-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa4">'
+            "eLife assessment"
+            "</self-uri>"
+            '<self-uri content-type="referee-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa3">'
+            "Reviewer #1 (Public Review):"
+            "</self-uri>"
+            '<self-uri content-type="referee-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa2">'
+            "Reviewer #2 (Public Review):"
+            "</self-uri>"
+            '<self-uri content-type="referee-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa1">'
+            "Reviewer #3 (Public Review):"
+            "</self-uri>"
+            '<self-uri content-type="author-comment"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa0">'
+            "Author response:"
+            "</self-uri>"
+            "</event>"
+            "</pub-history>"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        # invoke
+        result = pub_history.add_pub_history_tag(root, history_event_data, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf-8"), expected)
+
+    def test_no_pub_history_tag(self):
+        "test if no pub-history tag can be found or added"
+        root = ElementTree.fromstring("<root />")
+        history_event_data = [{"foo": "bar"}]
+        identifier = "identifier"
+        expected = "<root />"
+        # invoke
+        result = pub_history.add_pub_history_tag(root, history_event_data, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf-8"), expected)
+
+    def test_no_history_data(self):
+        "test if no history event data is supplied"
+        root = ElementTree.fromstring("<root />")
+        history_event_data = []
+        identifier = "identifier"
+        expected = "<root />"
+        # invoke
+        result = pub_history.add_pub_history_tag(root, history_event_data, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf-8"), expected)
+
+
+class TestAddPubHistory(unittest.TestCase):
+    "tests for prc.add_pub_history()"
+
+    def setUp(self):
+        # register XML namespaces
+        xmlio.register_xmlns()
+
+        self.xml_string_template = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<front>"
+            "<article-meta>%s</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        self.history_data = [
+            {
+                "type": "preprint",
+                "date": "2022-11-22",
+                "doi": "10.1101/2022.11.08.515698",
+                "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
+                "versionIdentifier": "2",
+                "published": "2022-11-22",
+                "content": [
+                    {
+                        "type": "computer-file",
+                        "url": (
+                            "s3://transfers-elife/biorxiv_Current_Content/November_2022/"
+                            "23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca"
+                        ),
+                    }
+                ],
+            },
+            {
+                "type": "reviewed-preprint",
+                "date": "2023-01-25T14:00:00+00:00",
+                "identifier": "85111",
+                "doi": "10.7554/eLife.85111.1",
+                "versionIdentifier": "1",
+                "license": "http://creativecommons.org/licenses/by/4.0/",
+                "published": "2023-01-25T14:00:00+00:00",
+            },
+            {
+                "type": "reviewed-preprint",
+                "date": "2023-05-10T14:00:00+00:00",
+                "identifier": "85111",
+                "doi": "10.7554/eLife.85111.2",
+                "versionIdentifier": "2",
+                "license": "http://creativecommons.org/licenses/by/4.0/",
+                "published": "2023-05-10T14:00:00+00:00",
+            },
+        ]
+        self.identifier = "test.zip"
+        # expected history XML string for when using the input values
+        self.xml_output = (
+            "<pub-history>"
+            "<event>"
+            "<event-desc>This manuscript was published as a preprint.</event-desc>"
+            '<date date-type="preprint" iso-8601-date="2022-11-22">'
+            "<day>22</day>"
+            "<month>11</month>"
+            "<year>2022</year>"
+            "</date>"
+            '<self-uri content-type="preprint"'
+            ' xlink:href="https://doi.org/10.1101/2022.11.08.515698" />'
+            "</event>"
+            "<event>"
+            "<event-desc>This manuscript was published as a reviewed preprint.</event-desc>"
+            '<date date-type="reviewed-preprint" iso-8601-date="2023-01-25">'
+            "<day>25</day>"
+            "<month>01</month>"
+            "<year>2023</year>"
+            "</date>"
+            '<self-uri content-type="reviewed-preprint"'
+            ' xlink:href="https://doi.org/10.7554/eLife.85111.1" />'
+            "</event>"
+            "<event>"
+            "<event-desc>The reviewed preprint was revised.</event-desc>"
+            '<date date-type="reviewed-preprint" iso-8601-date="2023-05-10">'
+            "<day>10</day>"
+            "<month>05</month>"
+            "<year>2023</year>"
+            "</date>"
+            '<self-uri content-type="reviewed-preprint"'
+            ' xlink:href="https://doi.org/10.7554/eLife.85111.2" />'
+            "</event>"
+            "</pub-history>"
+        )
+
+    def test_add_pub_history(self):
+        "test adding to an existing pub-history tag"
+        xml_string = self.xml_string_template % "<pub-history />"
+        expected = bytes(self.xml_string_template % self.xml_output, encoding="utf-8")
+        root = ElementTree.fromstring(xml_string)
+        root_output = pub_history.add_pub_history(
+            root, self.history_data, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+
+    def test_no_data(self):
+        "test for if there is no data to be added"
+        # use xlink:href in the sample and the xmlns is kept in the output
+        xml_string = (
+            self.xml_string_template % '<ext-link xlink:href="https://example.org" />'
+        )
+        history_data = None
+        expected = bytes(xml_string, encoding="utf-8")
+        root = ElementTree.fromstring(xml_string)
+        root_output = pub_history.add_pub_history(root, history_data, self.identifier)
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+
+    def test_after_history_tag(self):
+        "test adding a pub-history tag after an existing history tag"
+        xml_string = self.xml_string_template % "<history />"
+        expected = bytes(
+            self.xml_string_template % ("<history />" + self.xml_output),
+            encoding="utf-8",
+        )
+        root = ElementTree.fromstring(xml_string)
+        root_output = pub_history.add_pub_history(
+            root, self.history_data, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+
+    def test_elocation_id_tag(self):
+        "test pub-history tag should be added after the elocation-id tag"
+        xml_string = self.xml_string_template % "<elocation-id />"
+        expected = bytes(
+            self.xml_string_template % ("<elocation-id />" + self.xml_output),
+            encoding="utf-8",
+        )
+        root = ElementTree.fromstring(xml_string)
+        root_output = pub_history.add_pub_history(
+            root, self.history_data, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+
+    def test_no_article_meta(self):
+        "test if there is no article-meta tag"
+        xml_string = "<article />"
+        expected = b"<article />"
+        root = ElementTree.fromstring(xml_string)
+        root_output = pub_history.add_pub_history(
+            root, self.history_data, self.identifier
+        )
+        self.assertEqual(ElementTree.tostring(root_output), expected)
+
+
+class TestAddPubHistoryMeca(unittest.TestCase):
+    "tests for add_pub_history_meca()"
+
+    def setUp(self):
+        v1_events = (
+            "<event>"
+            "<event-desc>Preprint posted</event-desc>"
+            '<date date-type="preprint" iso-8601-date="2024-04-27">'
+            "<day>27</day>"
+            "<month>04</month>"
+            "<year>2024</year>"
+            "</date>"
+            '<self-uri content-type="preprint"'
+            ' xlink:href="https://doi.org/10.1101/2024.04.25.591185" />'
+            "</event>"
+            "<event>"
+            "<event-desc>Reviewed preprint v1</event-desc>"
+            '<date date-type="reviewed-preprint" iso-8601-date="2024-07-17">'
+            "<day>17</day>"
+            "<month>07</month>"
+            "<year>2024</year>"
+            "</date>"
+            '<self-uri content-type="reviewed-preprint"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1" />'
+            '<self-uri content-type="editor-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa4">'
+            "eLife assessment"
+            "</self-uri>"
+            '<self-uri content-type="referee-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa3">'
+            "Reviewer #1 (Public Review):"
+            "</self-uri>"
+            '<self-uri content-type="referee-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa2">'
+            "Reviewer #2 (Public Review):"
+            "</self-uri>"
+            '<self-uri content-type="referee-report"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa1">'
+            "Reviewer #3 (Public Review):"
+            "</self-uri>"
+            '<self-uri content-type="author-comment"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.1.sa0">'
+            "Author response:"
+            "</self-uri>"
+            "</event>"
+        )
+        v2_events = (
+            "<event>"
+            "<event-desc>Reviewed preprint v2</event-desc>"
+            '<date date-type="reviewed-preprint" iso-8601-date="2024-07-18">'
+            "<day>18</day>"
+            "<month>07</month>"
+            "<year>2024</year>"
+            "</date>"
+            '<self-uri content-type="reviewed-preprint"'
+            ' xlink:href="https://doi.org/10.7554/eLife.99854.2" />'
+            "</event>"
+        )
+        self.expected_v1_pub_history = (
+            "<pub-history>" "%s" "</pub-history>"
+        ) % v1_events
+        self.expected_v2_pub_history = ("<pub-history>" "%s" "%s" "</pub-history>") % (
+            v1_events,
+            v2_events,
+        )
+
+    @patch("docmaptools.parse.get_web_content")
+    def test_add_pub_history_meca(self, fake_get):
+        fake_get.side_effect = mock_get_web_content
+        root = ElementTree.fromstring(
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            "<history />"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        docmap_string = read_fixture("99854.json", mode="r")
+        identifier = "10.7554/eLife.99854.2"
+        expected = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<front>"
+            "<article-meta>"
+            "<history />"
+            "%s"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        ) % self.expected_v1_pub_history
+        # invoke
+        result = pub_history.add_pub_history_meca(
+            root, HISTORY_DATA_99854[0:2], docmap_string, identifier
+        )
+        # assert
+        xml_string = ElementTree.tostring(result).decode("utf-8")
+        self.assertEqual(xml_string, expected)
+
+    @patch("docmaptools.parse.get_web_content")
+    def test_insert_near_elocation_id(self, fake_get):
+        "test for inserting pub-history near the elocation-id tag and no history tag"
+        fake_get.side_effect = mock_get_web_content
+        root = ElementTree.fromstring(
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            "<elocation-id />"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        docmap_string = read_fixture("99854.json", mode="r")
+        identifier = "10.7554/eLife.99854.2"
+        expected = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<front>"
+            "<article-meta>"
+            "<elocation-id />"
+            "%s"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        ) % self.expected_v1_pub_history
+        # invoke
+        result = pub_history.add_pub_history_meca(
+            root, HISTORY_DATA_99854[0:2], docmap_string, identifier
+        )
+        # assert
+        xml_string = ElementTree.tostring(result).decode("utf-8")
+        self.assertEqual(xml_string, expected)
+
+    @patch("docmaptools.parse.get_web_content")
+    def test_multiple_history_events(self, fake_get):
+        "test more than one version DOI in history data"
+        fake_get.side_effect = mock_get_web_content
+        root = ElementTree.fromstring(
+            "<article>"
+            "<front>"
+            "<article-meta>"
+            "<elocation-id />"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        )
+        docmap_string = read_fixture("99854.json", mode="r")
+        identifier = "10.7554/eLife.99854.3"
+        expected = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<front>"
+            "<article-meta>"
+            "<elocation-id />"
+            "%s"
+            "</article-meta>"
+            "</front>"
+            "</article>"
+        ) % self.expected_v2_pub_history
+        # invoke
+        result = pub_history.add_pub_history_meca(
+            root, HISTORY_DATA_99854, docmap_string, identifier
+        )
+        # assert
+        xml_string = ElementTree.tostring(result).decode("utf-8")
+        self.assertEqual(xml_string, expected)
+
+        # self.assertTrue(False)
+
+    def test_no_article_meta(self):
+        "test if XML has no article-meta tag"
+        xml_string = b"<article />"
+        root = ElementTree.fromstring(xml_string)
+        history_data = [{"type": "preprint"}]
+        docmap_string = {}
+        identifier = "10.7554/eLife.95901.1"
+        # invoke
+        result = pub_history.add_pub_history_meca(
+            root, history_data, docmap_string, identifier
+        )
+        # assert
+        self.assertEqual(ElementTree.tostring(result), xml_string)
+
+    def test_no_history_data(self):
+        "test if history_data argument is empty"
+        xml_string = b"<article />"
+        root = ElementTree.fromstring(xml_string)
+        history_data = []
+        docmap_string = {}
+        identifier = "10.7554/eLife.95901.1"
+        # invoke
+        result = pub_history.add_pub_history_meca(
+            root, history_data, docmap_string, identifier
+        )
+        # assert
+        self.assertEqual(ElementTree.tostring(result), xml_string)

--- a/tests/test_sub_article.py
+++ b/tests/test_sub_article.py
@@ -14,7 +14,12 @@ from elifearticle.article import (
 )
 from elifetools import xmlio
 from elifecleaner import configure_logging, LOGGER, parse, sub_article
-from tests.helpers import delete_files_in_folder, read_fixture, read_log_file_lines
+from tests.helpers import (
+    delete_files_in_folder,
+    FakeResponse,
+    read_fixture,
+    read_log_file_lines,
+)
 
 
 ARTICLE_TITLES = [
@@ -90,25 +95,6 @@ CONTENT_JSON = [
         ],
     },
 ]
-
-
-class FakeRequest:
-    def __init__(self):
-        self.headers = {}
-        self.body = None
-
-
-class FakeResponse:
-    def __init__(self, status_code, response_json=None, text="", content=None):
-        self.status_code = status_code
-        self.response_json = response_json
-        self.content = content
-        self.text = text
-        self.request = FakeRequest()
-        self.headers = {}
-
-    def json(self):
-        return self.response_json
 
 
 def editor_report_article_fixture(


### PR DESCRIPTION
To generate `<pub-history>` for both accepted submissions and preprint MECA XML, these are in a new module named `pub_history.py`, and include the two styles of output.

Re issue https://github.com/elifesciences/issues/issues/8586