### PR TITLE
Bug fix, support for if inline_graphic_index is 0 in block.py

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.74.0"
+__version__ = "0.74.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/block.py
+++ b/elifecleaner/block.py
@@ -134,7 +134,7 @@ def graphic_href_list(body_tag, index_groups):
     "collect a list of xlink:href values of graphic tags from the index_groups"
     href_list = []
     for group in index_groups:
-        if group.get("inline_graphic_index"):
+        if group.get("inline_graphic_index") is not None:
             inline_graphic_p = body_tag[group.get("inline_graphic_index")]
             inline_graphic_tag = inline_graphic_tag_from_tag(inline_graphic_p)
             image_href = utils.xlink_href(inline_graphic_tag)


### PR DESCRIPTION
The `<p>` tag which wraps an `<inline-graphic>` tag may be 0, and this bug fix will allow the value to be used, only `None` is ignored.

Re issue https://github.com/elifesciences/issues/issues/8947