### PR TITLE
Add equation module for disp-formula and inline-formula

### DIFF
--- a/elifecleaner/__init__.py
+++ b/elifecleaner/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.74.1"
+__version__ = "0.75.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/elifecleaner/equation.py
+++ b/elifecleaner/equation.py
@@ -1,0 +1,184 @@
+from xml.etree.ElementTree import SubElement
+from elifecleaner import block, utils
+from elifecleaner.fig import remove_tag_attributes
+
+
+def inline_formula_graphic_hrefs(sub_article_root, identifier):
+    "return a list of inline-formula inline-graphic tag xlink:href values"
+    body_tag = block.sub_article_tag_parts(sub_article_root)[1]
+    current_hrefs = []
+    if body_tag is not None:
+        for graphic_tag in sub_article_root.findall(".//inline-formula/inline-graphic"):
+            image_href = utils.xlink_href(graphic_tag)
+            if image_href:
+                current_hrefs.append(image_href)
+    return current_hrefs
+
+
+def transform_equations(sub_article_root, identifier):
+    "transform inline-graphic tags into disp-formula tags"
+    sub_article_id, body_tag = block.sub_article_tag_parts(sub_article_root)
+    if body_tag is not None:
+        # match paragraphs with data in them and record the tag indexes
+        index_groups = disp_formula_tag_index_groups(body_tag, identifier)
+        transform_disp_formulas(body_tag, index_groups, sub_article_id)
+    return sub_article_root
+
+
+def disp_formula_tag_index_groups(body_tag, identifier):
+    "find p tags which have inline-graphic tags to convert to disp-formula"
+    index_groups = []
+    tag_id_index = 0
+    for tag_index, parent_tag in enumerate(body_tag.iterfind(".//p")):
+        # count the inline-graphic tags to get an id value
+        if parent_tag.findall("inline-graphic") or parent_tag.findall(
+            "disp-formula/graphic"
+        ):
+            tag_id_index += 1
+        if block.is_p_inline_graphic(
+            tag=parent_tag,
+            sub_article_id=None,
+            p_tag_index=None,
+            identifier=identifier,
+        ):
+            detail = {
+                "label_index": None,
+                "caption_index": None,
+                "inline_graphic_index": tag_index,
+                "tag_index": tag_id_index,
+            }
+            index_groups.append(detail)
+    return index_groups
+
+
+def transform_disp_formulas(body_tag, index_groups, sub_article_id):
+    "transform p tags in the body_tag to disp-formula tags as listed in index_groups"
+    for group in reversed(index_groups):
+        index = group.get("tag_index")
+        transform_disp_formula(body_tag, index, group, sub_article_id)
+
+
+def formula_id(sub_article_id, index):
+    "create an id attribute for a disp-formula tag"
+    return "%sequ%s" % (sub_article_id, index)
+
+
+def formula_file_name(inf_file_name, sub_article_id, index):
+    "create a file name for an equation graphic file"
+    return inf_file_name.replace(
+        utils.inf_file_identifier(inf_file_name),
+        "%s-equ%s" % (sub_article_id, index),
+    )
+
+
+def transform_disp_formula(body_tag, index, group, sub_article_id):
+    "transform one set of p tags into disp-formula tags as specified in the group dict"
+    inline_graphic_p_tag = body_tag[group.get("inline_graphic_index")]
+    inline_graphic_tag = block.inline_graphic_tag_from_tag(inline_graphic_p_tag)
+    image_href = utils.xlink_href(inline_graphic_tag)
+
+    # rename the image file
+    new_file_name = formula_file_name(image_href, sub_article_id, index)
+
+    # graphic tag
+    block.set_graphic_tag(inline_graphic_p_tag, image_href, new_file_name)
+
+    # convert inline-graphic p tag and remove attributes
+    inline_graphic_p_tag.tag = "disp-formula"
+    inline_graphic_p_tag.set("id", formula_id(sub_article_id, index))
+
+    # delete the old inline-graphic tag
+    inline_graphic_p_tag.remove(inline_graphic_tag)
+
+
+def equation_inline_graphic_hrefs(sub_article_root, identifier):
+    "get inline-graphic xlink:href values to be disp-formula"
+    body_tag = block.sub_article_tag_parts(sub_article_root)[1]
+    href_list = []
+    equation_index_groups = []
+    if body_tag is not None:
+        # find paragraphs to be disp-formula data
+        equation_index_groups = disp_formula_tag_index_groups(body_tag, identifier)
+        href_list = block.graphic_href_list(body_tag, equation_index_groups)
+    return href_list
+
+
+def inline_equation_inline_graphic_hrefs(sub_article_root, identifier):
+    "get inline-graphic xlink:href values to be inline-formula"
+    body_tag = block.sub_article_tag_parts(sub_article_root)[1]
+    href_list = []
+    equation_index_groups = []
+    if body_tag is not None:
+        # find paragraphs with inline-formula data in them and record the tag indexes
+        equation_index_groups = inline_formula_tag_index_groups(body_tag, identifier)
+        href_list = block.graphic_href_list(body_tag, equation_index_groups)
+    return href_list
+
+
+def transform_inline_equations(sub_article_root, identifier):
+    "transform inline-graphic tags into inline-formula tags"
+    sub_article_id, body_tag = block.sub_article_tag_parts(sub_article_root)
+    if body_tag is not None:
+        # match paragraphs with data in them and record the tag indexes
+        index_groups = inline_formula_tag_index_groups(body_tag, identifier)
+        transform_inline_formulas(body_tag, index_groups, sub_article_id)
+    return sub_article_root
+
+
+def inline_formula_tag_index_groups(body_tag, identifier):
+    "find p tags which have inline-graphic tags to convert to inline-formula"
+    index_groups = []
+    tag_id_index = 0
+    for tag_index, parent_tag in enumerate(body_tag.iterfind(".//p")):
+        # count the inline-graphic tags to get an id value
+        if parent_tag.findall("inline-graphic") or parent_tag.findall(
+            "disp-formula/graphic"
+        ):
+            tag_id_index += 1
+
+        if (
+            parent_tag.tag == "p"
+            and parent_tag.find("inline-graphic") is not None
+            and not (
+                block.is_p_inline_graphic(
+                    tag=parent_tag,
+                    sub_article_id=None,
+                    p_tag_index=None,
+                    identifier=identifier,
+                )
+            )
+        ):
+            detail = {
+                "label_index": None,
+                "caption_index": None,
+                "inline_graphic_index": tag_index,
+                "tag_index": tag_id_index,
+            }
+
+            index_groups.append(detail)
+
+    return index_groups
+
+
+def transform_inline_formulas(body_tag, index_groups, sub_article_id):
+    "transform p tags in the body_tag to table-wrap tags as listed in table_index_groups"
+    for group in reversed(index_groups):
+        index = group.get("tag_index")
+        transform_inline_formula(body_tag, index, group, sub_article_id)
+
+
+def transform_inline_formula(body_tag, index, group, sub_article_id):
+    "transform one set of p tags into inline-formula tags as specified in the group dict"
+    inline_graphic_p_tag = body_tag[group.get("inline_graphic_index")]
+    inline_graphic_tag = block.inline_graphic_tag_from_tag(inline_graphic_p_tag)
+    image_href = utils.xlink_href(inline_graphic_tag)
+
+    # rename the inline-graphic tag to inline-formula
+    remove_tag_attributes(inline_graphic_tag)
+    inline_graphic_tag.tag = "inline-formula"
+    inline_graphic_tag.set("id", formula_id(sub_article_id, index))
+
+    # add inline-graphic tag
+    new_inline_graphic_tag = SubElement(inline_graphic_tag, "inline-graphic")
+    new_file_name = formula_file_name(image_href, sub_article_id, index)
+    new_inline_graphic_tag.set("{http://www.w3.org/1999/xlink}href", new_file_name)

--- a/tests/test_equation.py
+++ b/tests/test_equation.py
@@ -1,0 +1,398 @@
+import unittest
+from xml.etree import ElementTree
+from elifetools import xmlio
+from elifecleaner import equation
+
+
+class TestInlineFormulaGraphicHrefs(unittest.TestCase):
+    "tests for equation.inline_formula_graphic_hrefs()"
+
+    def test_graphic_hrefs(self):
+        "get a list of xlink:href values from inline-formula inline-graphic"
+        xml_string = (
+            b'<sub-article xmlns:xlink="http://www.w3.org/1999/xlink" id="sa1">'
+            b"<body>"
+            b'<p>First paragraph with an inline equation <inline-formula id="sa1equ1">'
+            b'<inline-graphic xlink:href="elife-sa1-equ1.jpg" />'
+            b"</inline-formula>.</p>"
+            b"<p>Following is a display formula:</p>"
+            b'<p><inline-graphic xlink:href="elife-inf2.jpg" /></p>'
+            b"</body>"
+            b"</sub-article>"
+        )
+        identifier = "test.zip"
+        tag = ElementTree.fromstring(xml_string)
+        expected = ["elife-sa1-equ1.jpg"]
+        result = equation.inline_formula_graphic_hrefs(tag, identifier)
+        self.assertEqual(result, expected)
+
+    def test_graphic_hrefs_no_match(self):
+        "empty list of xlink:href values when there is no matching tag"
+        xml_string = (
+            b'<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<body><p/></body>"
+            b"</sub-article>"
+        )
+        identifier = "test.zip"
+        tag = ElementTree.fromstring(xml_string)
+        expected = []
+        result = equation.inline_formula_graphic_hrefs(tag, identifier)
+        self.assertEqual(result, expected)
+
+
+class TestTransformEquations(unittest.TestCase):
+    "tests for transform_equations()"
+
+    def test_transform_equations(self):
+        "test converting inline-graphic tags to disp-formula"
+        xmlio.register_xmlns()
+        sub_article_root = ElementTree.fromstring(
+            '<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<p>First paragraph with an inline equation"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/>.</p>'
+            "<p>Following is a display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+            "</sub-article>"
+        )
+        identifier = "10.7554/eLife.95901.1"
+        expected = (
+            '<sub-article xmlns:xlink="http://www.w3.org/1999/xlink" id="sa1">'
+            "<body>"
+            "<p>First paragraph with an inline equation"
+            ' <inline-graphic xlink:href="elife-inf1.jpg" />.</p>'
+            "<p>Following is a display formula:</p>"
+            '<disp-formula id="sa1equ2">'
+            '<graphic mimetype="image" mime-subtype="jpg" xlink:href="elife-sa1-equ2.jpg" />'
+            "</disp-formula>"
+            "</body>"
+            "</sub-article>"
+        )
+        # invoke
+        result = equation.transform_equations(sub_article_root, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf8"), expected)
+
+
+class TestDispFormulaTagIndexGroups(unittest.TestCase):
+    "tests for disp_formula_tag_index_groups()"
+
+    def test_disp_formula(self):
+        "test finding XML to be converted to disp-formula"
+        body_tag = ElementTree.fromstring(
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First paragraph with an inline equation"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/>.</p>'
+            "<p>Following is a display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+        )
+        identifier = "10.7554/eLife.95901.1"
+        expected = [
+            {
+                "label_index": None,
+                "caption_index": None,
+                "inline_graphic_index": 2,
+                "tag_index": 2,
+            }
+        ]
+        # invoke
+        result = equation.disp_formula_tag_index_groups(body_tag, identifier)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestTransformDispFormulas(unittest.TestCase):
+    "tests for transform_disp_formulas()"
+
+    def test_transform_disp_formulas(self):
+        "convert inline-graphic tags to disp-formula"
+        xmlio.register_xmlns()
+        body_tag = ElementTree.fromstring(
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf1.jpg"/></p>'
+            "<p>Second display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+        )
+        index_groups = [
+            {
+                "inline_graphic_index": 1,
+                "tag_index": 1,
+            },
+            {
+                "inline_graphic_index": 3,
+                "tag_index": 2,
+            },
+        ]
+        sub_article_id = "sa1"
+        expected = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First display formula:</p>"
+            '<disp-formula id="sa1equ1">'
+            '<graphic mimetype="image" mime-subtype="jpg" xlink:href="elife-sa1-equ1.jpg" />'
+            "</disp-formula>"
+            "<p>Second display formula:</p>"
+            '<disp-formula id="sa1equ2">'
+            '<graphic mimetype="image" mime-subtype="jpg" xlink:href="elife-sa1-equ2.jpg" />'
+            "</disp-formula>"
+            "</body>"
+        )
+        # invoke
+        equation.transform_disp_formulas(body_tag, index_groups, sub_article_id)
+        # assert
+        self.assertEqual(ElementTree.tostring(body_tag).decode("utf8"), expected)
+
+
+class TestFormulaId(unittest.TestCase):
+    "tests for formula_id()"
+
+    def test_formula_id(self):
+        "test generating an id for an XML formula or equation"
+        sub_article_id = "sa1"
+        index = 1
+        expected = "sa1equ1"
+        # invoke
+        result = equation.formula_id(sub_article_id, index)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestFormulaFileName(unittest.TestCase):
+    "tests for formula_file_name()"
+
+    def test_formula_file_name(self):
+        "test generating a file name for a equation or formula graphic"
+        inf_file_name = "elife-95901-inf1.jpg"
+        sub_article_id = "sa1"
+        index = "1"
+        expected = "elife-95901-sa1-equ1.jpg"
+        # invoke
+        result = equation.formula_file_name(inf_file_name, sub_article_id, index)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestTransformDispFormula(unittest.TestCase):
+    "tests for transform_disp_formula()"
+
+    def test_transform_disp_formula(self):
+        "test converting a single inline-graphic p tag into disp-formula"
+        xmlio.register_xmlns()
+        body_tag = ElementTree.fromstring(
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf1.jpg"/></p>'
+            "<p>Second display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+        )
+        index = "2"
+        group = {
+            "inline_graphic_index": 3,
+            "tag_index": 2,
+        }
+        sub_article_id = "sa1"
+        expected = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf1.jpg" /></p>'
+            "<p>Second display formula:</p>"
+            '<disp-formula id="sa1equ2">'
+            '<graphic mimetype="image" mime-subtype="jpg" xlink:href="elife-sa1-equ2.jpg" />'
+            "</disp-formula>"
+            "</body>"
+        )
+        # invoke
+        equation.transform_disp_formula(body_tag, index, group, sub_article_id)
+        # assert
+        self.assertEqual(ElementTree.tostring(body_tag).decode("utf8"), expected)
+
+
+class TestEquationInlineGraphicHrefs(unittest.TestCase):
+    "tests for equation_inline_graphic_hrefs()"
+
+    def test_equation_inline(self):
+        "test collecting href values for disp-formula"
+        sub_article_root = ElementTree.fromstring(
+            '<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<p>First paragraph with an inline equation"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/>.</p>'
+            "<p>Following is a display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+            "</sub-article>"
+        )
+        identifier = "10.7554/eLife.95901.1"
+        expected = ["elife-inf2.jpg"]
+        # invoke
+        result = equation.equation_inline_graphic_hrefs(sub_article_root, identifier)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestInlineEquationInlineGraphicHrefs(unittest.TestCase):
+    "tests for inline_equation_inline_graphic_hrefs()"
+
+    def test_inline_equation_inline(self):
+        "test collecting href values for inline-formula"
+        sub_article_root = ElementTree.fromstring(
+            '<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<p>First paragraph with an inline equation"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/>.</p>'
+            "<p>Following is a display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+            "</sub-article>"
+        )
+        identifier = "10.7554/eLife.95901.1"
+        expected = ["elife-inf1.jpg"]
+        # invoke
+        result = equation.inline_equation_inline_graphic_hrefs(
+            sub_article_root, identifier
+        )
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestTransformInlineEquations(unittest.TestCase):
+    "tests for transform_inline_equations()"
+
+    def test_transform_inline_equations(self):
+        "test converting inline-graphic tags to inline-formula"
+        xmlio.register_xmlns()
+        sub_article_root = ElementTree.fromstring(
+            '<sub-article id="sa1" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<p>First paragraph with an inline equation"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/>.</p>'
+            "<p>Following is a display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+            "</sub-article>"
+        )
+        identifier = "10.7554/eLife.95901.1"
+        expected = (
+            '<sub-article xmlns:xlink="http://www.w3.org/1999/xlink" id="sa1">'
+            "<body>"
+            '<p>First paragraph with an inline equation <inline-formula id="sa1equ1">'
+            '<inline-graphic xlink:href="elife-sa1-equ1.jpg" />'
+            "</inline-formula>.</p>"
+            "<p>Following is a display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg" /></p>'
+            "</body>"
+            "</sub-article>"
+        )
+        # invoke
+        result = equation.transform_inline_equations(sub_article_root, identifier)
+        # assert
+        self.assertEqual(ElementTree.tostring(result).decode("utf8"), expected)
+
+
+class TestInlineFormulaTagIndexGroups(unittest.TestCase):
+    "tests for inline_formula_tag_index_groups()"
+
+    def test_inline_formula(self):
+        "test finding XML to be converted to inline-formula"
+        body_tag = ElementTree.fromstring(
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First paragraph with an inline equation"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/>.</p>'
+            "<p>Following is a display formula:</p>"
+            '<p><inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+        )
+        identifier = "10.7554/eLife.95901.1"
+        expected = [
+            {
+                "label_index": None,
+                "caption_index": None,
+                "inline_graphic_index": 0,
+                "tag_index": 1,
+            }
+        ]
+        # invoke
+        result = equation.inline_formula_tag_index_groups(body_tag, identifier)
+        # assert
+        self.assertEqual(result, expected)
+
+
+class TestTransformInlineFormulas(unittest.TestCase):
+    "tests for transform_inline_formulas()"
+
+    def test_transform_inline_formulas(self):
+        "convert inline-graphic tags to inline-formula"
+        xmlio.register_xmlns()
+        body_tag = ElementTree.fromstring(
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First inline formula:"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/></p>'
+            "<p>Second inline formula:"
+            ' <inline-graphic xlink:href="elife-inf2.jpg"/></p>'
+            "</body>"
+        )
+        index_groups = [
+            {
+                "inline_graphic_index": 0,
+                "tag_index": 1,
+            },
+            {
+                "inline_graphic_index": 1,
+                "tag_index": 2,
+            },
+        ]
+        sub_article_id = "sa1"
+        expected = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<p>First inline formula: <inline-formula id="sa1equ1">'
+            '<inline-graphic xlink:href="elife-sa1-equ1.jpg" />'
+            "</inline-formula></p>"
+            '<p>Second inline formula: <inline-formula id="sa1equ2">'
+            '<inline-graphic xlink:href="elife-sa1-equ2.jpg" />'
+            "</inline-formula></p>"
+            "</body>"
+        )
+        # invoke
+        equation.transform_inline_formulas(body_tag, index_groups, sub_article_id)
+        # assert
+        self.assertEqual(ElementTree.tostring(body_tag).decode("utf8"), expected)
+
+
+class TestTransformInlineFormula(unittest.TestCase):
+    "tests for transform_inline_formula()"
+
+    def test_transform_inline_formula(self):
+        "test converting a single inline-graphic p tag into inline-formula"
+        xmlio.register_xmlns()
+        body_tag = ElementTree.fromstring(
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First inline formula:"
+            ' <inline-graphic xlink:href="elife-inf1.jpg"/></p>'
+            "<p>Second inline formula:"
+            ' <inline-graphic xlink:href="elife-inf2.jpg"/> and more text.</p>'
+            "</body>"
+        )
+        index = "1"
+        group = {
+            "inline_graphic_index": 1,
+            "tag_index": 2,
+        }
+        sub_article_id = "sa1"
+        expected = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<p>First inline formula:"
+            ' <inline-graphic xlink:href="elife-inf1.jpg" /></p>'
+            "<p>Second inline formula:"
+            ' <inline-formula id="sa1equ1">'
+            '<inline-graphic xlink:href="elife-sa1-equ1.jpg" />'
+            "</inline-formula> and more text.</p>"
+            "</body>"
+        )
+        # invoke
+        equation.transform_inline_formula(body_tag, index, group, sub_article_id)
+        # assert
+        self.assertEqual(ElementTree.tostring(body_tag).decode("utf8"), expected)


### PR DESCRIPTION
A new module holds functions to transform `<inline-graphic>` into either `<disp-formula>` or `<inline-formula>`.

Re issue https://github.com/elifesciences/issues/issues/8947